### PR TITLE
Clang compatibility fixes

### DIFF
--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -1,4 +1,5 @@
 #include "zmq_helpers.hpp"
+#include <string>
 
 namespace zmq {
 


### PR DESCRIPTION
It seems that the `string` header was missing from `zmq_helpers.cpp`.

This was the original error:
```
  CXX      src/libprime_server_la-zmq_helpers.lo
src/zmq_helpers.cpp:117:51: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >'
      return send(static_cast<const void*>(message.data()), message.size(), flags);
                                                  ^
src/zmq_helpers.cpp:141:27: note: in instantiation of function template specialization 'zmq::socket_t::send<std::__1::basic_string<char,
      std::__1::char_traits<char>, std::__1::allocator<char> > >' requested here
  template bool socket_t::send<std::string>(const std::string&,int);
                          ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:188:33: note: template is
      declared here
    class _LIBCPP_TYPE_VIS_ONLY basic_string;
                                ^
src/zmq_helpers.cpp:125:38: error: no matching member function for call to 'send'
        total += static_cast<size_t>(send<container_t>(message, (last_message == &message ? 0 : ZMQ_SNDMORE) | flags));
                                     ^~~~~~~~~~~~~~~~~
src/zmq_helpers.cpp:143:29: note: in instantiation of function template specialization 'zmq::socket_t::send_all<std::__1::basic_string<char,
      std::__1::char_traits<char>, std::__1::allocator<char> > >' requested here
  template size_t socket_t::send_all<std::string>(const std::list<std::string>&,int);
                            ^
src/zmq_helpers.cpp:116:20: note: candidate template ignored: substitution failure [with container_t = std::__1::basic_string<char,
      std::__1::char_traits<char>, std::__1::allocator<char> >]
    bool socket_t::send(const container_t& message, int flags) {
                   ^
In file included from src/zmq_helpers.cpp:1:
In file included from ./prime_server/zmq_helpers.hpp:7:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/list:226:9: error: implicit
      instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    _Tp __value_;
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/list:954:36: note: in instantiation of
      template class 'std::__1::__list_node<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, void *>'
      requested here
        return base::__end_.__prev_->__value_;
                                   ^
src/zmq_helpers.cpp:122:44: note: in instantiation of member function 'std::__1::list<std::__1::basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >
      >::back' requested here
      const auto* last_message = &messages.back();
                                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/iosfwd:188:33: note: template is
      declared here
    class _LIBCPP_TYPE_VIS_ONLY basic_string;
                                ^
3 errors generated.
make: *** [src/libprime_server_la-zmq_helpers.lo] Error 1
```