### PR TITLE
close bad requests

### DIFF
--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -125,7 +125,7 @@ namespace prime_server {
 
   class http_server_t : public server_t<http_request_t, http_request_t::info_t> {
    public:
-    http_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false);
+    http_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false, size_t max_request_size = 1024);
     virtual ~http_server_t();
    protected:
     virtual void enqueue(const void* message, size_t size, const std::string& requester, http_request_t& request);

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -18,7 +18,7 @@ namespace prime_server {
 
   class netstring_server_t : public server_t<std::string, uint64_t> {
    public:
-    netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false);
+    netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false, size_t max_request_size = 1024);
     virtual ~netstring_server_t();
    protected:
     virtual void enqueue(const void* message, size_t size, const std::string& requester, std::string& buffer);

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -55,7 +55,7 @@ namespace prime_server {
   class server_t {
    public:
     static_assert(std::is_pod<request_info_t>::value, "server requires POD types for request info");
-    server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false);
+    server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log = false, size_t max_request_size = 1024);
     virtual ~server_t();
     void serve();
    protected:
@@ -80,6 +80,7 @@ namespace prime_server {
     zmq::socket_t proxy;
     zmq::socket_t loopback;
     bool log;
+    size_t max_request_size;
     //a record of what open connections we have
     //TODO: keep time of last session activity and clear out stale sessions
     std::unordered_map<std::string, request_container_t> sessions;

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -565,8 +565,8 @@ namespace prime_server {
     return response;
   }
 
-  http_server_t::http_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log):
-    server_t<http_request_t, http_request_t::info_t>::server_t(context, client_endpoint, proxy_endpoint, result_endpoint, log), request_id(0) {
+  http_server_t::http_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log, size_t max_request_size):
+    server_t<http_request_t, http_request_t::info_t>::server_t(context, client_endpoint, proxy_endpoint, result_endpoint, log, max_request_size), request_id(0) {
   }
   http_server_t::~http_server_t(){}
 

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -80,8 +80,8 @@ namespace prime_server {
     return collected;
   }
 
-  netstring_server_t::netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log):
-    server_t<std::string, uint64_t>::server_t(context, client_endpoint, proxy_endpoint, result_endpoint, log), request_id(0) {
+  netstring_server_t::netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log, size_t max_request_size):
+    server_t<std::string, uint64_t>::server_t(context, client_endpoint, proxy_endpoint, result_endpoint, log, max_request_size), request_id(0) {
   }
   netstring_server_t::~netstring_server_t(){}
   void netstring_server_t::enqueue(const void* message, size_t size, const std::string& requester, std::string& buffer) {

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -249,7 +249,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&http_server_t::serve,
-     http_server_t(context, "ipc://test_http_server", "ipc://test_http_proxy_upstream", "ipc://test_http_results")));
+     http_server_t(context, "ipc://test_http_server", "ipc://test_http_proxy_upstream", "ipc://test_http_results", false, 9000)));
     server.detach();
 
     //load balancer for parsing

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -145,7 +145,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc://test_netstring_server", "ipc://test_netstring_proxy_upstream", "ipc://test_netstring_results")));
+      netstring_server_t(context, "ipc://test_netstring_server", "ipc://test_netstring_proxy_upstream", "ipc://test_netstring_results", false, 9000)));
     server.detach();
 
     //load balancer for parsing


### PR DESCRIPTION
fixes #22: bad requests will have their sessions closed
fixes a bug where large requests could get through so long as they were the first thing requested
fixing that bug made the tests fail (they were exploiting it). so made max request size configurable through the server_t api to allow large requests in tests
