### PR TITLE
use /tmp for ipc sockets because some systems dont like relative paths

### DIFF
--- a/m4/prime_server.m4
+++ b/m4/prime_server.m4
@@ -30,7 +30,7 @@ AC_DEFUN([CHECK_PRIME_SERVER],
         	[AC_LANG_PUSH([C++])
 		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <prime_server/prime_server.hpp>]],
 			[[zmq::context_t c;
-			 prime_server::proxy_t(c,"ipc://up","ipc://down");]])],
+			 prime_server::proxy_t(c,"ipc:///tmp/up","ipc:///tmp/down");]])],
 			ax_cv_prime_server=yes, ax_cv_prime_server=no)
 		AC_LANG_POP([C++])
 	])

--- a/src/prime_echod.cpp
+++ b/src/prime_echod.cpp
@@ -34,8 +34,8 @@ int main(int argc, char** argv) {
 
   //change these to tcp://known.ip.address.with:port if you want to do this across machines
   zmq::context_t context;
-  std::string result_endpoint = "ipc://result_endpoint";
-  std::string proxy_endpoint = "ipc://proxy_endpoint";
+  std::string result_endpoint = "ipc:///tmp/result_endpoint";
+  std::string proxy_endpoint = "ipc:///tmp/proxy_endpoint";
 
   //server
   std::thread server_thread = std::thread(std::bind(&http_server_t::serve,
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
   std::list<std::thread> echo_worker_threads;
   for(size_t i = 0; i < worker_concurrency; ++i) {
     echo_worker_threads.emplace_back(std::bind(&worker_t::work,
-      worker_t(context, proxy_endpoint + "_downstream", "ipc://NO_ENDPOINT", result_endpoint,
+      worker_t(context, proxy_endpoint + "_downstream", "ipc:///tmp/NO_ENDPOINT", result_endpoint,
       [] (const std::list<zmq::message_t>& job, void* request_info) {
         worker_t::result_t result{false};
         try {

--- a/src/prime_serverd.cpp
+++ b/src/prime_serverd.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
 
   //number of jobs to do or server endpoint
   size_t requests = 0;
-  std::string server_endpoint = "ipc://server_endpoint";
+  std::string server_endpoint = "ipc:///tmp/server_endpoint";
   if(std::string(argv[1]).find("://") != std::string::npos)
     server_endpoint = argv[1];
   else
@@ -37,9 +37,9 @@ int main(int argc, char** argv) {
 
   //change these to tcp://known.ip.address.with:port if you want to do this across machines
   zmq::context_t context;
-  std::string result_endpoint = "ipc://result_endpoint";
-  std::string parse_proxy_endpoint = "ipc://parse_proxy_endpoint";
-  std::string compute_proxy_endpoint = "ipc://compute_proxy_endpoint";
+  std::string result_endpoint = "ipc:///tmp/result_endpoint";
+  std::string parse_proxy_endpoint = "ipc:///tmp/parse_proxy_endpoint";
+  std::string compute_proxy_endpoint = "ipc:///tmp/compute_proxy_endpoint";
 
   //server
   std::thread server_thread = std::thread(std::bind(&http_server_t::serve,
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
   std::list<std::thread> compute_worker_threads;
   for(size_t i = 0; i < worker_concurrency; ++i) {
     compute_worker_threads.emplace_back(std::bind(&worker_t::work,
-      worker_t(context, compute_proxy_endpoint + "_downstream", "ipc://NO_ENDPOINT", result_endpoint,
+      worker_t(context, compute_proxy_endpoint + "_downstream", "ipc:///tmp/NO_ENDPOINT", result_endpoint,
       [] (const std::list<zmq::message_t>& job, void* request_info) {
         //check if its prime
         size_t prime = *static_cast<const size_t*>(job.front().data());

--- a/test/zmq.cpp
+++ b/test/zmq.cpp
@@ -26,7 +26,7 @@ namespace {
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     #endif
     #endif
-    server.bind("ipc://test_server");
+    server.bind("ipc:///tmp/test_server");
 
     zmq::message_t identity;
 
@@ -63,7 +63,7 @@ namespace {
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     #endif
     #endif
-    client.connect("ipc://test_server");
+    client.connect("ipc:///tmp/test_server");
     #if ZMQ_VERSION_MAJOR >= 4
     #if ZMQ_VERSION_MINOR >= 1
     client.recv_all(0);
@@ -110,8 +110,8 @@ namespace {
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     #endif
     #endif
-    server.bind("ipc://test_server");
-    client.connect("ipc://test_server");
+    server.bind("ipc:///tmp/test_server");
+    client.connect("ipc:///tmp/test_server");
 
     //greet each other
     zmq::message_t identity;
@@ -167,8 +167,8 @@ namespace {
     zmq::message_t identity(static_cast<void *>(new unsigned char[7]{'a','b','c','d','e','f','g'}), 7);
     dealer.setsockopt(ZMQ_IDENTITY, identity.data(), identity.size());
 
-    dealer.connect("ipc://test_router_dealer");
-    router.bind("ipc://test_router_dealer");
+    dealer.connect("ipc:///tmp/test_router_dealer");
+    router.bind("ipc:///tmp/test_router_dealer");
 
     //make lots of little requests
     size_t request_count = 100000;
@@ -239,10 +239,10 @@ namespace {
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     #endif
     #endif
-    client.connect("ipc://test_server");
-    server.bind("ipc://test_server");
-    dealer.connect("ipc://test_router_dealer");
-    router.bind("ipc://test_router_dealer");
+    client.connect("ipc:///tmp/test_server");
+    server.bind("ipc:///tmp/test_server");
+    dealer.connect("ipc:///tmp/test_router_dealer");
+    router.bind("ipc:///tmp/test_router_dealer");
 
     //great eachother
     #if ZMQ_VERSION_MAJOR >= 4


### PR DESCRIPTION
as seen in this users vagrant setup valhalla/chef-valhalla#72