### PR TITLE
Fix build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,13 +85,13 @@ prime_echod_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 check_PROGRAMS = test/zmq test/netstring test/http
 test_zmq_SOURCES = test/zmq.cpp
 test_zmq_CPPFLAGS = $(DEPS_CFLAGS)
-test_zmq_LDADD = $(DEPS_LIBS) libprime_server.la
+test_zmq_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 test_netstring_SOURCES = test/netstring.cpp
 test_netstring_CPPFLAGS = $(DEPS_CFLAGS)
-test_netstring_LDADD = $(DEPS_LIBS) libprime_server.la
+test_netstring_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 test_http_SOURCES = test/http.cpp
 test_http_CPPFLAGS = $(DEPS_CFLAGS)
-test_http_LDADD = $(DEPS_LIBS) libprime_server.la
+test_http_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 
 
 TESTS = $(check_PROGRAMS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,23 +63,23 @@ bin_PROGRAMS = \
 prime_serverd_SOURCES = \
         src/prime_serverd.cpp
 prime_serverd_CPPFLAGS = $(DEPS_CFLAGS)
-prime_serverd_LDADD = $(DEPS_LIBS) libprime_server.la
+prime_serverd_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 prime_httpd_SOURCES = \
         src/prime_httpd.cpp
 prime_httpd_CPPFLAGS = $(DEPS_CFLAGS)
-prime_httpd_LDADD = $(DEPS_LIBS) libprime_server.la
+prime_httpd_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 prime_proxyd_SOURCES = \
         src/prime_proxyd.cpp
 prime_proxyd_CPPFLAGS = $(DEPS_CFLAGS)
-prime_proxyd_LDADD = $(DEPS_LIBS) libprime_server.la
+prime_proxyd_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 prime_workerd_SOURCES = \
         src/prime_workerd.cpp
 prime_workerd_CPPFLAGS = $(DEPS_CFLAGS)
-prime_workerd_LDADD = $(DEPS_LIBS) libprime_server.la
+prime_workerd_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 prime_echod_SOURCES = \
         src/prime_echod.cpp
 prime_echod_CPPFLAGS = $(DEPS_CFLAGS)
-prime_echod_LDADD = $(DEPS_LIBS) libprime_server.la
+prime_echod_LDADD = $(DEPS_LIBS) libprime_server.la -lpthread
 
 # tests
 check_PROGRAMS = test/zmq test/netstring test/http

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -156,10 +156,11 @@ namespace prime_server {
   void netstring_server_t::dequeue(const uint64_t& request_info, size_t length) {
     //NOTE: netstring protocol is always keep alive so we leave the session intact
     auto removed = requests.erase(request_info);
-    if(removed != 1)
+    if(removed != 1) {
       LOG_WARN("Unknown or timed-out request id: " + std::to_string(request_info));
-    else if(log)
+    } else if(log) {
       log_transaction(request_info, "REPLIED");
+    }
   }
 
 }

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -17,18 +17,16 @@ namespace prime_server {
     int disabled = 0;
     server.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-#if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 2
+#ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-#endif
 #endif
     server.connect(server_endpoint.c_str());
   }
   client_t::~client_t(){}
   void client_t::batch() {
 #if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 2
+#if ZMQ_VERSION_MINOR >= 1
     //swallow the first response as its just for connecting
     //TODO: make sure it looks right
     server.recv_all(0);
@@ -85,11 +83,9 @@ namespace prime_server {
     int disabled = 0;
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-#if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 2
+#ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-#endif
 #endif
     client.bind(client_endpoint.c_str());
 

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -18,7 +18,7 @@ namespace prime_server {
     server.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
 #if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 1
+#if ZMQ_VERSION_MINOR >= 2
     int enabled = 1;
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
 #endif
@@ -28,7 +28,7 @@ namespace prime_server {
   client_t::~client_t(){}
   void client_t::batch() {
 #if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 1
+#if ZMQ_VERSION_MINOR >= 2
     //swallow the first response as its just for connecting
     //TODO: make sure it looks right
     server.recv_all(0);
@@ -86,7 +86,7 @@ namespace prime_server {
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
 #if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 1
+#if ZMQ_VERSION_MINOR >= 2
     int enabled = 1;
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
 #endif

--- a/test/zmq.cpp
+++ b/test/zmq.cpp
@@ -20,11 +20,9 @@ namespace {
     int disabled = 0;
     server.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
+    #ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
     #endif
     server.bind("ipc://test_server");
 
@@ -57,11 +55,9 @@ namespace {
     int disabled = 0;
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
+    #ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
     #endif
     client.connect("ipc://test_server");
     #if ZMQ_VERSION_MAJOR >= 4
@@ -103,12 +99,10 @@ namespace {
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
+    #ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
     #endif
     server.bind("ipc://test_server");
     client.connect("ipc://test_server");
@@ -232,12 +226,10 @@ namespace {
     dealer.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
     router.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     router.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
+    #ifdef ZMQ_STREAM_NOTIFY
     int enabled = 1;
     client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
     server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
     #endif
     client.connect("ipc://test_server");
     server.bind("ipc://test_server");


### PR DESCRIPTION
1. `ZMQ_STREAM_NOTIFY` actually is avaliable since zeromq 4.2. See http://lists.zeromq.org/pipermail/zeromq-dev/2015-September/029619.html

2. The flag `-lpthread` seems to be required

3. The if statement without braces causes syntax error in newer gcc versions (gcc5.2 and 5.3)

```
src/netstring_protocol.cpp: In member function ‘virtual void prime_server::netstring_server_t::dequeue(const uint64_t&, size_t)’:
src/netstring_protocol.cpp:161:5: error: ‘else’ without a previous ‘if’
     else if(log)
     ^
```