### PR TITLE
socket connect and disconnect notification handling for v4.0 and up

### DIFF
--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -17,12 +17,6 @@ namespace prime_server {
     int disabled = 0;
     server.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-#if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-#endif
-#endif
     server.connect(server_endpoint.c_str());
   }
   client_t::~client_t(){}
@@ -85,12 +79,6 @@ namespace prime_server {
     int disabled = 0;
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-#if ZMQ_VERSION_MAJOR >= 4
-#if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-#endif
-#endif
     client.bind(client_endpoint.c_str());
 
     proxy.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));

--- a/test/zmq.cpp
+++ b/test/zmq.cpp
@@ -20,12 +20,6 @@ namespace {
     int disabled = 0;
     server.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
-    #endif
     server.bind("ipc:///tmp/test_server");
 
     zmq::message_t identity;
@@ -57,12 +51,6 @@ namespace {
     int disabled = 0;
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
-    #endif
     client.connect("ipc:///tmp/test_server");
     #if ZMQ_VERSION_MAJOR >= 4
     #if ZMQ_VERSION_MINOR >= 1
@@ -103,13 +91,6 @@ namespace {
     server.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     client.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
-    #endif
     server.bind("ipc:///tmp/test_server");
     client.connect("ipc:///tmp/test_server");
 
@@ -232,13 +213,6 @@ namespace {
     dealer.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
     router.setsockopt(ZMQ_SNDHWM, &disabled, sizeof(disabled));
     router.setsockopt(ZMQ_RCVHWM, &disabled, sizeof(disabled));
-    #if ZMQ_VERSION_MAJOR >= 4
-    #if ZMQ_VERSION_MINOR >= 1
-    int enabled = 1;
-    client.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    server.setsockopt(ZMQ_STREAM_NOTIFY, &enabled, sizeof(enabled));
-    #endif
-    #endif
     client.connect("ipc:///tmp/test_server");
     server.bind("ipc:///tmp/test_server");
     dealer.connect("ipc:///tmp/test_router_dealer");


### PR DESCRIPTION
fixes #37 

basically `zmq_stream_notify` may or may not be defined in various versions of zmq from 4.1.x up to 4.2 and further. on ubuntu 14.04 it is defined in libzmq3 (4.0.4) but on ubuntu 16.04 its not defined in libzmq3 (4.1.4). the reason we cared whether it was defined or not was because we needed to know whether the socket would send a blank message upon connect or disconnect, since we needed to know if we should elide one or not. this was fairly complicated for a time... zmq 4.0 did not send these messages, but at some point 4.2 RCs  started sending them for disconnect but not for connect (https://github.com/zeromq/libzmq/pull/1487). Thankfully before 4.2 was released the behaviour was stabilised. which means we can make our code much simpler :smile: 

instead of checking the version and seeing if the notify is defined we just need to say if version >= 4.1 then elide connect and disconnect messages. now it is possible you could checkout a version of the code where 4.2 was not behaving the same as 4.1 but thats on you :wink: 