### PR TITLE
pedantry of this level for the sake of mixing compilers in trusty

### DIFF
--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -57,7 +57,7 @@ namespace prime_server {
     virtual std::string to_string() const = 0;
    protected:
     enum state_t { METHOD, MESSAGE, CODE, PATH, VERSION, HEADERS, BODY, CHUNKS };
-    void flush_stream(const state_t state);
+    virtual void flush_stream(const state_t state);
 
     //state for streaming parsing
     const char *cursor, *end, *delimiter;
@@ -78,6 +78,7 @@ namespace prime_server {
     std::string path;
     query_t query;
 
+    virtual ~http_request_t();
     http_request_t();
     http_request_t(const method_t& method, const std::string& path, const std::string& body = "", const query_t& query = query_t{},
                    const headers_t& headers = headers_t{}, const std::string& version = "HTTP/1.1");
@@ -99,7 +100,7 @@ namespace prime_server {
     static http_request_t from_string(const char* start, size_t length);
     static query_t split_path_query(std::string& path);
     std::list<http_request_t> from_stream(const char* start, size_t length, size_t max_size = std::numeric_limits<size_t>::max());
-    void flush_stream();
+    virtual void flush_stream();
     size_t size() const;
 
    protected:
@@ -114,6 +115,7 @@ namespace prime_server {
     uint16_t code;
     std::string message;
 
+    virtual ~http_response_t();
     http_response_t();
     http_response_t(unsigned code, const std::string& message, const std::string& body = "", const headers_t& headers = headers_t{},
                     const std::string& version = "HTTP/1.1");
@@ -123,7 +125,7 @@ namespace prime_server {
     std::list<http_response_t> from_stream(const char* start, size_t length);
     static std::string generic(unsigned code, const std::string message, const headers_t& headers = headers_t{}, const std::string& body = "",
                                const std::string& version = "HTTP/1.1");
-    void flush_stream();
+    virtual void flush_stream();
 
    protected:
     std::string log_line;

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -263,6 +263,8 @@ namespace prime_server {
     body.clear();
   }
 
+  http_request_t::~http_request_t(){};
+
   http_request_t::http_request_t():http_entity_t("", headers_t{}, ""){
     path = "";
     flush_stream();
@@ -498,6 +500,8 @@ namespace prime_server {
   size_t http_request_t::size() const {
     return consumed + partial_buffer.size();
   }
+
+  http_response_t::~http_response_t(){};
 
   http_response_t::http_response_t():http_entity_t("", headers_t{}, ""){
     message = "";


### PR DESCRIPTION
many many thanks to @zerebubuth for his detective skills in figuring this out.

so c++11 was still 'experimental' in versions `4.x` of gcc this means that c++11 datatypes, specifically in this case `std::unordered_map`, had different sizes between compilers.

```
kkreiser@klaptop:~$ g++-4.8 -std=c++11 a.cpp; ./a.out
48
kkreiser@klaptop:~$ g++-4.9 -std=c++11 a.cpp; ./a.out
56
kkreiser@klaptop:~$ cat a.cpp
#include <iostream>
#include <unordered_map>
int main(void) {
  std::cout << sizeof(std::unordered_map<int,int>) << std::endl;
  return 0;
}
```

the problem here was a bit tricky though. basically we have a couple of structs that keep `std::unordered_map`s. the thing is they dont define destructors but they do define constructors (since they have some not default ones). the problem is that the a ppa build machine running trusty will have a compiler with version 4.8. it will build into the library these constructors allocating 48 bytes of memory. however when you make use of this to write an link a program against it whatever compiler you are using must make a destructor for this class (since one wasnt provided in the library). in my case i'm using 4.9 on trusty. so when my compiler creates that destructor it wants to deallocate 56 bytes and whatevers after it in the object at the wrong location in memory and all of that.

this is not good. and you dont get any kind of warning about it until you run the program and it gives a memory access out of bounds and crashes. so anyway, the fix.. all you need to do is make sure the destructing code is in the same place (the library) as the constructing code. in this case it meant defining destructors.

for the sake of reproduction all you need is this:

```
kkreiser@klaptop:~$ cat foo.hpp
#include <unordered_map>
#include <string>
namespace foo {
 struct qux {
  qux();
  int baz();
  std::unordered_map<std::string, int> m{{"meaning_of_life",42}};
  std::string s;
 };
}
kkreiser@klaptop:~$ cat foo.cpp
#include "foo.hpp"
namespace foo {
  qux::qux(){};
  int qux::baz() {
    return m["meaning_of_life"];
  }
}
kkreiser@klaptop:~$ cat a.cpp
#include <foo.hpp>
int main(void) {
  return foo::qux().baz();
}
kkreiser@klaptop:~$ rm -f *.o libfoo*; g++-4.8 -pthread -std=c++11 -shared -fPIC -o libfoo.so foo.cpp; g++-4.9 -std=c++11 -pthread -ggdb -g a.cpp -I. -L. -lfoo; ./a.out; echo $?
Speicherzugriffsfehler (Speicherabzug geschrieben)
139
kkreiser@klaptop:~$ rm -f *.o libfoo*; g++-4.8 -pthread -std=c++11 -shared -fPIC -o libfoo.so foo.cpp; g++-4.8 -std=c++11 -pthread -ggdb -g a.cpp -I. -L. -lfoo; ./a.out; echo $?
42
```

Make the compilers match and it works perfectly.. 