### PR TITLE
version.sh portability

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -8,9 +8,9 @@ if [ ! -f prime_server/prime_server.hpp ]; then
 	exit 1
 fi
 
-major=$(grep -m1 -F VERSION_MAJOR prime_server/prime_server.hpp | sed -e "s/.*MAJOR \([0-9][0-9]*\)/\1/g")
-minor=$(grep -m1 -F VERSION_MINOR prime_server/prime_server.hpp | sed -e "s/.*MINOR \([0-9][0-9]*\)/\1/g")
-patch=$(grep -m1 -F VERSION_PATCH prime_server/prime_server.hpp | sed -e "s/.*PATCH \([0-9][0-9]*\)/\1/g")
+major=$(grep -F VERSION_MAJOR prime_server/prime_server.hpp | sed -e "s/.*MAJOR \([0-9][0-9]*\)/\1/g" -e 1q)
+minor=$(grep -F VERSION_MINOR prime_server/prime_server.hpp | sed -e "s/.*MINOR \([0-9][0-9]*\)/\1/g" -e 1q)
+patch=$(grep -F VERSION_PATCH prime_server/prime_server.hpp | sed -e "s/.*PATCH \([0-9][0-9]*\)/\1/g" -e 1q)
 
 if [ -z $major ] || [ -z $minor ] || [ -z $patch ]; then
 	echo "Malformed version information"

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #grabs the version string from the header file for use autotools
 #which then throws it into a pc file so that pkg-config can use it


### PR DESCRIPTION
`version.sh` is Bourne‐compatible, so there’s no need to pull in bash.

POSIX doesn’t define `-m` for grep, and OpenBSD’s grep doesn’t implement it. Instead, we can pass 1q to sed, which quits sed after the first result.