### PR TITLE
make compilation outside of the project directory possible

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 AM_LDFLAGS = @COVERAGE_LDFLAGS@
-AM_CPPFLAGS = -Iprime_server
-AM_CXXFLAGS = -Iprime_server
+AM_CPPFLAGS = -I@abs_srcdir@/prime_server
+AM_CXXFLAGS = -I@abs_srcdir@/prime_server
 LIBTOOL_DEPS = @LIBTOOL_DEPS@
 libtool: $(LIBTOOL_DEPS)
 	$(SHELL) ./config.status libtool


### PR DESCRIPTION
With autotools, you can compile on another directory. For example, using:
```sh
git clone --recursive https://github.com/kevinkreiser/prime_server.git
cd prime_server
./autogen.sh
cd ..
mkdir prime_server-release
cd prime_server-release
../prime_server/configure
make
```

it's not working here:
```
$ make
  CXX      src/libprime_server_la-prime_server.lo
../prime_server/src/prime_server.cpp:6:28: fatal error: prime_server.hpp: No such file or directory
 #include "prime_server.hpp"
                            ^
compilation terminated.
Makefile:904: recipe for target 'src/libprime_server_la-prime_server.lo' failed
make: *** [src/libprime_server_la-prime_server.lo] Error 1
```

A workaround is to use `../prime_server/configure CXXFLAGS=-I../prime_server/prime_server`, but that's not great.

This patch make this scheme working. My autotools skills are very low, so I don't know if this is the clean way of doing it.

PS: comparable problems are present in every repository of valhalla.