### PR TITLE
proxy traffic shaping via worker heart beat info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ test-driver
 test/zmq
 test/netstring
 test/http
+test/shaping
 test/*.log
 test/*.trs
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ prime_echod_CPPFLAGS = $(DEPS_CFLAGS)
 prime_echod_LDADD = $(DEPS_LIBS) libprime_server.la
 
 # tests
-check_PROGRAMS = test/zmq test/netstring test/http
+check_PROGRAMS = test/zmq test/netstring test/http test/shaping
 test_zmq_SOURCES = test/zmq.cpp
 test_zmq_CPPFLAGS = $(DEPS_CFLAGS)
 test_zmq_LDADD = $(DEPS_LIBS) libprime_server.la
@@ -92,7 +92,9 @@ test_netstring_LDADD = $(DEPS_LIBS) libprime_server.la
 test_http_SOURCES = test/http.cpp
 test_http_CPPFLAGS = $(DEPS_CFLAGS)
 test_http_LDADD = $(DEPS_LIBS) libprime_server.la
-
+test_shaping_SOURCES = test/shaping.cpp
+test_shaping_CPPFLAGS = $(DEPS_CFLAGS)
+test_shaping_LDADD = $(DEPS_LIBS) libprime_server.la
 
 TESTS = $(check_PROGRAMS)
 TEST_EXTENSIONS = .sh

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -137,7 +137,7 @@ namespace prime_server {
                   const std::string& result_endpoint, bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
     virtual ~http_server_t();
    protected:
-    virtual bool enqueue(const void* message, size_t size, const std::string& requester, http_request_t& request);
+    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, http_request_t& request);
     virtual void dequeue(const http_request_t::info_t& request_info, size_t length);
    protected:
     uint64_t request_id;

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -138,7 +138,7 @@ namespace prime_server {
     virtual ~http_server_t();
    protected:
     virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, http_request_t& request);
-    virtual void dequeue(const http_request_t::info_t& request_info, size_t length);
+    virtual void dequeue(const std::list<zmq::message_t>& messages);
    protected:
     uint64_t request_id;
   };

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -36,7 +36,7 @@ namespace prime_server {
                        const std::string& result_endpoint, bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
     virtual ~netstring_server_t();
    protected:
-    virtual bool enqueue(const void* message, size_t size, const std::string& requester, netstring_entity_t& buffer);
+    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer);
     virtual void dequeue(const uint64_t& request_info, size_t length);
     uint64_t request_id;
   };

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -37,7 +37,7 @@ namespace prime_server {
     virtual ~netstring_server_t();
    protected:
     virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer);
-    virtual void dequeue(const uint64_t& request_info, size_t length);
+    virtual void dequeue(const std::list<zmq::message_t>& messages);
     uint64_t request_id;
   };
 

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -113,10 +113,11 @@ namespace prime_server {
 
     //we want a fifo queue in the case that the proxy doesnt care what worker to send jobs to
     //having this constraint does also require that we store a bidirectional mapping between
-    //worker addresses and their heartbeats
+    //worker addresses and their heartbeats. since heartbeats are application defined we only
+    //store them once (they could be larger) and opt for storing the worker addresses duplicated
     std::list<zmq::message_t> fifo;
     std::unordered_map<zmq::message_t, std::list<zmq::message_t>::iterator> workers;
-    std::unordered_map<const zmq::message_t*, const zmq::message_t*> heart_beats;
+    std::unordered_map<const zmq::message_t*, zmq::message_t> heart_beats;
   };
 
   //get work from a load balancer proxy letting it know when you are idle

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -61,7 +61,6 @@ namespace prime_server {
     virtual ~server_t();
     void serve();
    protected:
-    void handle_response(std::list<zmq::message_t>& messages);
     void handle_request(std::list<zmq::message_t>& messages);
     //implementing class shall:
     //  take the request_container pump more bytes into and get back out >= 0 whole request objects

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -115,6 +115,7 @@ namespace prime_server {
     struct result_t {
       bool intermediate;
       std::list<std::string> messages;
+      std::string heart_beat;
     };
     using work_function_t = std::function<result_t (const std::list<zmq::message_t>&, void*)>;
     using cleanup_function_t = std::function<void ()>;
@@ -129,7 +130,8 @@ namespace prime_server {
     zmq::socket_t loopback;
     work_function_t work_function;
     cleanup_function_t cleanup_function;
-    long heart_beat;
+    long heart_beat_interval;
+    std::string heart_beat;
   };
 
 }

--- a/prime_server/zmq_helpers.hpp
+++ b/prime_server/zmq_helpers.hpp
@@ -67,4 +67,15 @@ namespace zmq {
 
 }
 
+namespace std {
+  //make messages hashable in the same way that strings are
+  template<>
+  struct hash<zmq::message_t> : public __hash_base<size_t, zmq::message_t> {
+    size_t operator()(const zmq::message_t& __m) const noexcept
+    {
+      return std::_Hash_impl::hash(__m.data(), __m.size());
+    }
+  };
+}
+
 #endif //__ZMQ_HELPERS_HPP__

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -73,7 +73,7 @@ namespace {
   const prime_server::headers_t::value_type CORS{"Access-Control-Allow-Origin", "*"};
   const request_exception_t RESPONSE_400(prime_server::http_response_t(400, "Bad Request", "Malformed HTTP request", {CORS}));
   const request_exception_t RESPONSE_413(prime_server::http_response_t(413, "Request Entity Too Large", "The HTTP request was too large", {CORS}));
-  const request_exception_t RESPONSE_500(prime_server::http_response_t(500, "Internal Server Error", "The HTTP request method is not supported", {CORS}));
+  const request_exception_t RESPONSE_500(prime_server::http_response_t(500, "Internal Server Error", "The server encountered an unexpected condition which prevented it from fulfilling the request", {CORS}));
   const request_exception_t RESPONSE_501(prime_server::http_response_t(501, "Not Implemented", "The HTTP request method is not supported", {CORS}));
   const request_exception_t RESPONSE_505(prime_server::http_response_t(505, "HTTP Version Not Supported", "The HTTP request version is not supported", {CORS}));
 

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -646,11 +646,11 @@ namespace prime_server {
   }
   http_server_t::~http_server_t(){}
 
-  bool http_server_t::enqueue(const void* message, size_t size, const std::string& requester, http_request_t& request) {
+  bool http_server_t::enqueue(const zmq::message_t& requester, const zmq::message_t& message, http_request_t& request) {
     //do some parsing
     std::list<http_request_t> parsed_requests;
     try {
-      parsed_requests = request.from_stream(static_cast<const char*>(message), size, max_request_size);
+      parsed_requests = request.from_stream(static_cast<const char*>(message.data()), message.size(), max_request_size);
     }//something went wrong, either in parsing or size limitation
     catch(const request_exception_t& e) {
       client.send(requester, ZMQ_SNDMORE | ZMQ_DONTWAIT);

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -123,11 +123,11 @@ namespace prime_server {
 
   netstring_server_t::~netstring_server_t(){}
 
-  bool netstring_server_t::enqueue(const void* message, size_t size, const std::string& requester, netstring_entity_t& request) {
+  bool netstring_server_t::enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& request) {
     //do some parsing
     std::list<netstring_entity_t> parsed_requests;
     try {
-      parsed_requests = request.from_stream(static_cast<const char*>(message), size, max_request_size);
+      parsed_requests = request.from_stream(static_cast<const char*>(message.data()), message.size(), max_request_size);
     }//something went wrong either bad request or too long
     catch(const std::runtime_error& e) {
       client.send(requester, ZMQ_SNDMORE | ZMQ_DONTWAIT);

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -16,6 +16,8 @@ namespace {
     logging::log(log_line);
   }
 
+  const std::string INTERNAL_ERROR(prime_server::netstring_entity_t::to_string("INTERNAL_ERROR: empty response"));
+
 }
 
 namespace prime_server {
@@ -160,9 +162,12 @@ namespace prime_server {
       LOG_WARN("Unknown or timed-out request id: " + std::to_string(request_info));
       return;
     }
-    //reply to the client
+    //reply to the client with the response or an error
     client.send(request->second, ZMQ_SNDMORE | ZMQ_DONTWAIT);
-    client.send(messages.back(), ZMQ_DONTWAIT);
+    if(messages.size() == 2)
+      client.send(messages.back(), ZMQ_DONTWAIT);
+    else
+      client.send(INTERNAL_ERROR, ZMQ_DONTWAIT);
     if(log)
       log_transaction(request_info, "REPLIED");
     //cleanup, but leave the session as netstring is always keep alive

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -222,7 +222,7 @@ namespace prime_server {
             //remember this workers address
             worker = workers.emplace_hint(worker, std::move(messages.front()), std::prev(fifo.end()));
             //remember which worker owns this heartbeat
-            heart_beats.emplace(&fifo.back(), &worker->first);
+            heart_beats.emplace(&fifo.back(), worker->first);
           }//not new but update heartbeat just in case
           else
             *worker->second = std::move(*std::next(messages.begin()));
@@ -251,10 +251,10 @@ namespace prime_server {
             hb_itr = heart_beats.find(heart_beat);
           }
           //send it on to the first bored worker
-          downstream.send(*hb_itr->second, ZMQ_DONTWAIT | ZMQ_SNDMORE);
+          downstream.send(hb_itr->second, ZMQ_DONTWAIT | ZMQ_SNDMORE);
           downstream.send_all(messages, ZMQ_DONTWAIT);
           //they are dead to us until they report back
-          auto worker_itr = workers.find(*hb_itr->second);
+          auto worker_itr = workers.find(hb_itr->second);
           fifo.erase(worker_itr->second);
           workers.erase(worker_itr);
           heart_beats.erase(hb_itr);

--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -32,7 +32,6 @@ namespace zmq {
           delete message;
         });
     }
-
     message_t::message_t(size_t size) {
       //make the c message
       zmq_msg_t* message = new zmq_msg_t();

--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -64,11 +64,11 @@ namespace zmq {
     }
 
     bool message_t::operator==(const message_t& other) const {
-      return std::memcmp(data(), other.data(), size()) == 0;
+      return size() == other.size() && std::memcmp(data(), other.data(), size()) == 0;
     }
 
     bool message_t::operator!=(const message_t& other) const {
-      return std::memcmp(data(), other.data(), size()) != 0;
+      return size() != other.size() || std::memcmp(data(), other.data(), size()) != 0;
     }
 
     socket_t::socket_t(const context_t& context, int socket_type):context(context) {

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -291,7 +291,7 @@ namespace {
 
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
-      worker_t(context, "ipc:///tmp/test_http_proxy_downstream", "ipc:///tmp/NONE", "ipc:///tmp/test_http_results",
+      worker_t(context, "ipc:///tmp/test_http_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_http_results",
       [] (const std::list<zmq::message_t>& job, void* request_info) {
         //could be a get or a post
         auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
@@ -313,8 +313,8 @@ namespace {
     worker.detach();
 
     //make a bunch of clients
-    std::thread client1(std::bind(&http_client_work, context));
-    std::thread client2(std::bind(&http_client_work, context));
+    std::thread client1(std::bind(&http_client_work, std::ref(context)));
+    std::thread client2(std::bind(&http_client_work,  std::ref(context)));
     client1.join();
     client2.join();
   }

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -26,6 +26,12 @@ namespace {
       int disabled = 0;
       proxy.setsockopt(ZMQ_LINGER, &disabled, sizeof(disabled));
     }
+    //easier to test with straight up strings
+    bool enqueue(const std::string& requester, const std::string& message, http_request_t& request) {
+      zmq::message_t r(&const_cast<char&>(requester.front()), requester.size(), [](void*, void*){});
+      zmq::message_t m(&const_cast<char&>(message.front()), message.size(), [](void*, void*){});
+      return http_server_t::enqueue(r, m, request);
+    }
   };
 
   struct testable_http_request_t : public http_request_t {
@@ -47,9 +53,9 @@ namespace {
 
     testable_http_request_t request;
     std::string incoming("GET /irgendwelle/pfad HTTP/1.1\r");
-    server.enqueue(static_cast<const void*>(incoming.data()), incoming.size(), "irgendjemand", request);
+    server.enqueue("irgendjemand", incoming, request);
     incoming ="\nContent-Length: 7\r\n\r\ngohtlosGET /annrer/pfad?aafrag=gel HTTP/1.0\r\n\r\nGET sell_siehscht_du_au_noed";
-    server.enqueue(static_cast<const void*>(incoming.data()), incoming.size(), "irgendjemand", request);
+    server.enqueue("irgendjemand", incoming, request);
 
     if(server.request_id != 2)
       throw std::runtime_error("Wrong number of requests were forwarded");

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -159,7 +159,7 @@ namespace {
 
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
-      worker_t(context, "ipc:///tmp/test_netstring_proxy_downstream", "ipc:///tmp/NONE", "ipc:///tmp/test_netstring_results",
+      worker_t(context, "ipc:///tmp/test_netstring_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_netstring_results",
       [] (const std::list<zmq::message_t>& job, void*) {
         worker_t::result_t result{false};
         auto request = netstring_entity_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
@@ -171,8 +171,8 @@ namespace {
     worker.detach();
 
     //make a bunch of clients
-    std::thread client1(std::bind(&netstring_client_work, context));
-    std::thread client2(std::bind(&netstring_client_work, context));
+    std::thread client1(std::bind(&netstring_client_work, std::ref(context)));
+    std::thread client2(std::bind(&netstring_client_work, std::ref(context)));
     client1.join();
     client2.join();
   }

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -26,6 +26,12 @@ namespace {
       int disabled = 0;
       proxy.setsockopt(ZMQ_LINGER, &disabled, sizeof(disabled));
     }
+    //easier to test with straight up strings
+    bool enqueue(const std::string& requester, const std::string& message, netstring_entity_t& buffer) {
+      zmq::message_t r(&const_cast<char&>(requester.front()), requester.size(), [](void*, void*){});
+      zmq::message_t m(&const_cast<char&>(message.front()), message.size(), [](void*, void*){});
+      return netstring_server_t::enqueue(r, m, buffer);
+    }
   };
 
   class testable_netstring_client_t : public netstring_client_t {
@@ -42,9 +48,9 @@ namespace {
 
     netstring_entity_t request;
     std::string incoming("1");
-    server.enqueue(static_cast<const void*>(incoming.data()), incoming.size(), "irgendjemand", request);
+    server.enqueue("irgendjemand", incoming, request);
     incoming = "2:abgeschnitte,3:mer,5:welle,5:luege,5:oeb's,4:guet,4:isch,81:du_siehscht_mi_noed";
-    server.enqueue(static_cast<const void*>(incoming.data()), incoming.size(), "irgendjemand", request);
+    server.enqueue("irgendjemand", incoming, request);
     if(server.request_id != 7)
       throw std::runtime_error("Wrong number of requests were forwarded");
     if(request.body != "du_siehscht_mi_noed")

--- a/test/shaping.cpp
+++ b/test/shaping.cpp
@@ -1,0 +1,147 @@
+#include "testing/testing.hpp"
+#include "prime_server.hpp"
+#include "netstring_protocol.hpp"
+
+#include <unistd.h>
+#include <functional>
+#include <memory>
+#include <unordered_set>
+#include <thread>
+#include <iterator>
+#include <cstdlib>
+#include <cstring>
+
+using namespace prime_server;
+
+namespace {
+
+  void netstring_client_work(zmq::context_t& context, const std::string& request, std::list<std::string>& responses, const std::string& endpoint, const size_t total, const size_t batch_size) {
+    //client makes requests and gets back responses in a batch fashion
+    auto request_str = netstring_entity_t::to_string(request);
+    netstring_client_t client(context, endpoint,
+      [&responses, request_str, total]() -> std::pair<const void*, size_t> {
+        //we want more requests
+        if(responses.size() < total)
+          return std::make_pair(static_cast<const void*>(request_str.c_str()), request_str.size());
+        //blank request means we are done
+        return std::make_pair(nullptr, 0);
+      },
+      [&responses, total](const void* data, size_t size) {
+        //get the result and tell if there is more or not
+        auto response = netstring_entity_t::from_string(static_cast<const char*>(data), size);
+        responses.push_back(response.body);
+        return responses.size() < total;
+      }, batch_size
+    );
+    //request and receive
+    client.batch();
+  }
+
+  void test_unshaped() {
+    zmq::context_t context;
+
+    //server
+    std::thread server(std::bind(&netstring_server_t::serve,
+      netstring_server_t(context, "ipc:///tmp/test_unshaped_server", "ipc:///tmp/test_unshaped_proxy_upstream", "ipc:///tmp/test_unshaped_results", false)));
+    server.detach();
+
+    //load balancer for parsing
+    std::thread proxy(std::bind(&proxy_t::forward,
+      proxy_t(context, "ipc:///tmp/test_unshaped_proxy_upstream", "ipc:///tmp/test_unshaped_proxy_downstream")));
+    proxy.detach();
+
+    //a or b workers
+    for(const auto& response : {std::string("A"), std::string("B")}) {
+      std::thread worker(std::bind(&worker_t::work,
+        worker_t(context, "ipc:///tmp/test_unshaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_unshaped_results",
+        [response] (const std::list<zmq::message_t>& job, void*) {
+          worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
+          return result;
+        }, [](){}, response
+      )));
+      worker.detach();
+    }
+
+    //make a client that makes one request at a time, so we can have our requests bounce between A and B workers
+    std::list<std::string> responses;
+    std::thread client(std::bind(&netstring_client_work, std::ref(context), "A", std::ref(responses), "ipc:///tmp/test_unshaped_server", 10000, 1));
+    client.join();
+    size_t as = 0;
+    size_t bs = 0;
+    for(const auto& response : responses) {
+      as += response == "A";
+      bs += response == "B";
+    }
+    if(as != bs)
+      throw std::logic_error("traffic should have evenly distributed");
+  }
+
+  void test_shaped() {
+    zmq::context_t context;
+
+    //server
+    std::thread server(std::bind(&netstring_server_t::serve,
+      netstring_server_t(context, "ipc:///tmp/test_shaped_server", "ipc:///tmp/test_shaped_proxy_upstream", "ipc:///tmp/test_shaped_results", false)));
+    server.detach();
+
+    //load balancer for parsing that favors heartbeats (ie workers) based on whats in the job to be forwarded
+    //returning a nullptr means you dont have a preference
+    std::thread proxy(std::bind(&proxy_t::forward,
+      proxy_t(context, "ipc:///tmp/test_shaped_proxy_upstream", "ipc:///tmp/test_shaped_proxy_downstream",
+        [](const std::list<zmq::message_t>& heart_beats, const std::list<zmq::message_t>& job) -> const zmq::message_t* {
+          //have a look at each heartbeat
+          for(const auto& heart_beat : heart_beats) {
+            //so the heartbeat is a single char either A or B
+            const auto& beat_type = static_cast<const char*>(heart_beat.data())[0];
+            //but the job is in netstring format, so either 1:A, or 1:B,
+            const auto& job_type = static_cast<const char*>(job.front().data())[2];
+            //do we like this heartbeat
+            if(beat_type == job_type)
+              return &heart_beat;
+          }
+          //all of the heartbeats sucked so pick whichever
+          return nullptr;
+        }
+      )));
+    proxy.detach();
+
+    //A or B workers
+    for(const auto& response : {std::string("A"), std::string("B")}) {
+      std::thread worker(std::bind(&worker_t::work,
+        worker_t(context, "ipc:///tmp/test_shaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_shaped_results",
+        [response] (const std::list<zmq::message_t>& job, void*) {
+          worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
+          return result;
+        }, [](){}, response
+      )));
+      worker.detach();
+    }
+
+    //make a client that makes one request at a time, so we can always be sure to have an A worker ready
+    std::list<std::string> responses;
+    std::thread client(std::bind(&netstring_client_work, std::ref(context), "A", std::ref(responses), "ipc:///tmp/test_shaped_server", 10000, 1));
+    client.join();
+    size_t as = 0;
+    size_t bs = 0;
+    for(const auto& response : responses) {
+      as += response == "A";
+      bs += response == "B";
+    }
+    if(as != 10000 || bs != 0)
+      throw std::logic_error("Only the A worker should have answered requests");
+  }
+
+}
+
+int main() {
+  //make this whole thing bail if it doesnt finish fast
+  //alarm(120);
+
+  testing::suite suite("shaping");
+
+  suite.test(TEST_CASE(test_unshaped));
+
+  suite.test(TEST_CASE(test_shaped));
+
+  return suite.tear_down();
+}


### PR DESCRIPTION
this ~~is the first step towards~~ adds support for #51 
support was requested in tangrams/paparazzi#1
it has the added benefit of being slightly faster in the limit as well

- [x] heart beats carry information optionally
- [x] proxy generically supports traffic shaping based on heart beats
- [x] reduce copying of `zmq::message_t` into `std::string` for the purpose of hashing
- [x] dont send the requester address through entire pipeline