### PR TITLE
roll our own murmur hash 3 so that clang and others will work

### DIFF
--- a/prime_server/zmq_helpers.hpp
+++ b/prime_server/zmq_helpers.hpp
@@ -3,11 +3,11 @@
 
 #include <zmq.h>
 #include <memory>
+#include <functional>
 #include <stdexcept>
 #include <list>
 #include <cassert>
 #include <cstring>
-#include <cstdlib>
 
 namespace zmq {
 

--- a/prime_server/zmq_helpers.hpp
+++ b/prime_server/zmq_helpers.hpp
@@ -7,6 +7,7 @@
 #include <list>
 #include <cassert>
 #include <cstring>
+#include <cstdlib>
 
 namespace zmq {
 
@@ -68,13 +69,8 @@ namespace zmq {
 }
 
 namespace std {
-  //make messages hashable in the same way that strings are
-  template<>
-  struct hash<zmq::message_t> : public __hash_base<size_t, zmq::message_t> {
-    size_t operator()(const zmq::message_t& __m) const noexcept
-    {
-      return std::_Hash_impl::hash(__m.data(), __m.size());
-    }
+  template<> struct hash<zmq::message_t> {
+    size_t operator()(const zmq::message_t& m) const noexcept;
   };
 }
 

--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -166,3 +166,168 @@ namespace zmq {
   template size_t socket_t::send_all<zmq::message_t>(const std::list<zmq::message_t>&,int);
 
 }
+
+//original at https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+namespace murmur_hash3 {
+
+  //left rotation without carry
+  inline uint32_t rotl32 (uint32_t x, int8_t r) { return (x << r) | (x >> (32 - r)); }
+  inline uint64_t rotl64 (uint64_t x, int8_t r) { return (x << r) | (x >> (64 - r)); }
+
+  //if your platform needs to do endian-swapping or can only handle aligned reads, do the conversion here
+  inline uint32_t getblock32 (const uint32_t * p, int i) { return p[i]; }
+  inline uint64_t getblock64 (const uint64_t * p, int i) { return p[i]; }
+
+  //finalization mix to force all bits of a hash block to avalanche
+  inline uint32_t fmix32 (uint32_t h) {
+    h ^= h >> 16; h *= 0x85ebca6b;
+    h ^= h >> 13; h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+  }
+  inline uint64_t fmix64 ( uint64_t k ) {
+    k ^= k >> 33; k *= 0xff51afd7ed558ccdLLU;
+    k ^= k >> 33; k *= 0xc4ceb9fe1a85ec53LLU;
+    k ^= k >> 33;
+    return k;
+  }
+
+  //32bit platform with 32bit hash
+  uint32_t murmur_hash3_x86_32(const void* key, int len, uint32_t seed) {
+    const uint8_t* data = static_cast<const uint8_t*>(key);
+    const int nblocks = len / 4;
+    uint32_t h1 = seed;
+    const uint32_t c1 = 0xcc9e2d51;
+    const uint32_t c2 = 0x1b873593;
+
+    //body
+    const uint32_t* blocks = static_cast<const uint32_t *>(static_cast<const void*>(data + nblocks * 4));
+    for (int i = -nblocks; i; i++) {
+      uint32_t k1 = getblock32(blocks, i);
+      k1 *= c1;
+      k1 = rotl32(k1, 15);
+      k1 *= c2;
+
+      h1 ^= k1;
+      h1 = rotl32(h1, 13);
+      h1 = h1 * 5 + 0xe6546b64;
+    }
+
+    //tail
+    const uint8_t* tail = static_cast<const uint8_t*>(data + nblocks * 4);
+    uint32_t k1 = 0;
+    switch (len & 3) {
+      case 3:
+        k1 ^= tail[2] << 16;
+      case 2:
+        k1 ^= tail[1] << 8;
+      case 1:
+        k1 ^= tail[0];
+        k1 *= c1;
+        k1 = rotl32(k1, 15);
+        k1 *= c2;
+        h1 ^= k1;
+    };
+
+    //finalization
+    h1 ^= len;
+    return fmix32(h1);
+  }
+
+  //64bit platform 128bit hash truncated to 64bits
+  uint64_t murmur_hash3_x64_128(const void * key, const int len, const uint32_t seed) {
+    const uint8_t* data = static_cast<const uint8_t*>(key);
+    const int nblocks = len / 16;
+    uint64_t h1 = seed;
+    uint64_t h2 = seed;
+    const uint64_t c1 = 0x87c37b91114253d5LLU;
+    const uint64_t c2 = 0x4cf5ad432745937fLLU;
+
+    //body
+    const uint64_t* blocks = static_cast<const uint64_t*>(static_cast<const void*>(data));
+    for (int i = 0; i < nblocks; i++) {
+      uint64_t k1 = getblock64(blocks, i * 2 + 0);
+      uint64_t k2 = getblock64(blocks, i * 2 + 1);
+      k1 *= c1;
+      k1 = rotl64(k1, 31);
+      k1 *= c2;
+      h1 ^= k1;
+      h1 = rotl64(h1, 27);
+      h1 += h2;
+      h1 = h1 * 5 + 0x52dce729;
+      k2 *= c2;
+      k2 = rotl64(k2, 33);
+      k2 *= c1;
+      h2 ^= k2;
+      h2 = rotl64(h2, 31);
+      h2 += h1;
+      h2 = h2 * 5 + 0x38495ab5;
+    }
+
+    //tail
+    const uint8_t * tail = (const uint8_t*) (data + nblocks * 16);
+    uint64_t k1 = 0;
+    uint64_t k2 = 0;
+    switch (len & 15) {
+      case 15:
+        k2 ^= static_cast<uint64_t>(tail[14]) << 48;
+      case 14:
+        k2 ^= static_cast<uint64_t>(tail[13]) << 40;
+      case 13:
+        k2 ^= static_cast<uint64_t>(tail[12]) << 32;
+      case 12:
+        k2 ^= static_cast<uint64_t>(tail[11]) << 24;
+      case 11:
+        k2 ^= static_cast<uint64_t>(tail[10]) << 16;
+      case 10:
+        k2 ^= static_cast<uint64_t>(tail[9]) << 8;
+      case 9:
+        k2 ^= static_cast<uint64_t>(tail[8]) << 0;
+        k2 *= c2;
+        k2 = rotl64(k2, 33);
+        k2 *= c1;
+        h2 ^= k2;
+      case 8:
+        k1 ^= static_cast<uint64_t>(tail[7]) << 56;
+      case 7:
+        k1 ^= static_cast<uint64_t>(tail[6]) << 48;
+      case 6:
+        k1 ^= static_cast<uint64_t>(tail[5]) << 40;
+      case 5:
+        k1 ^= static_cast<uint64_t>(tail[4]) << 32;
+      case 4:
+        k1 ^= static_cast<uint64_t>(tail[3]) << 24;
+      case 3:
+        k1 ^= static_cast<uint64_t>(tail[2]) << 16;
+      case 2:
+        k1 ^= static_cast<uint64_t>(tail[1]) << 8;
+      case 1:
+        k1 ^= static_cast<uint64_t>(tail[0]) << 0;
+        k1 *= c1;
+        k1 = rotl64(k1, 31);
+        k1 *= c2;
+        h1 ^= k1;
+    };
+
+    //finalization
+    h1 ^= len;
+    h2 ^= len;
+    h1 += h2;
+    h2 += h1;
+    h1 = fmix64(h1);
+    h2 = fmix64(h2);
+    h1 += h2;
+    h2 += h1;
+    return h1; //we only use the first 64 bits of this 128bit hash
+  }
+
+  //let the compiler pick which hash makes sense for your architecture
+  template<int> size_t specialized_hash_bytes(const void*, size_t);
+  template<> size_t specialized_hash_bytes<4>(const void* bytes, size_t length) { return murmur_hash3_x86_32(bytes, length, 1); }
+  template<> size_t specialized_hash_bytes<8>(const void* bytes, size_t length) { return murmur_hash3_x64_128(bytes, length, 1); }
+  inline size_t hash_bytes(const void* bytes, size_t length) { return specialized_hash_bytes<sizeof(size_t)>(bytes, length); }
+}
+
+namespace std {
+  size_t hash<zmq::message_t>::operator()(const zmq::message_t& m) const noexcept { return murmur_hash3::hash_bytes(m.data(), m.size()); }
+}


### PR DESCRIPTION
fixes #53 

so other compilers rightfully have other implementations of hashing for strings. conveniently gnu had a nice little abstraction called `_hash_bytes` but the first `_` should have given it away that it wasnt to be used publicly. in fact the header even says, dont use this its not meant to be public. maybe for inlining purposes they didnt hide it or something i dont know but anyway the c++ spec doesnt say that such a function should be provided it is a detail that is left up to the implementer of the specialization for `std::hash<std::string>`. so naturally when you go to clang, for example, the function isnt there and so you cant use it... and that all makes sense. i mean the standard probably on purpose doesnt dictate what kind of hash algorithm you can you for any random set of bytes, you might want your own. it was just convenient so i used it. but that was wrong.

so here instead of ripped off the author of the murmur hash algorithm and used that. it performs reasonably well in both speed and collision avoidance and will do different things depending on whether you need a 32 or 64bit hash (at compile time). ive noticed no difference in execution time of the tests but to really test this i would need to write a test to does lots of simultaneous clients.

@patriciogonzalezvivo this should build on mac brew now, give it a whirl