### PR TITLE
Request Cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ test/zmq
 test/netstring
 test/http
 test/shaping
+test/interrupt
 test/*.log
 test/*.trs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ compiler:
 env:
 before_install:
   - export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g"`
+  - sudo add-apt-repository -y ppa:kevinkreiser/libsodium
+  - sudo add-apt-repository -y ppa:kevinkreiser/libpgm
+  - sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
   - sudo add-apt-repository -y ppa:kevinkreiser/czmq
   - sudo apt-get update
 install:

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,7 +89,7 @@ prime_filed_CPPFLAGS = $(DEPS_CFLAGS)
 prime_filed_LDADD = $(DEPS_LIBS) libprime_server.la
 
 # tests
-check_PROGRAMS = test/zmq test/netstring test/http test/shaping
+check_PROGRAMS = test/zmq test/netstring test/http test/shaping test/interrupt
 test_zmq_SOURCES = test/zmq.cpp
 test_zmq_CPPFLAGS = $(DEPS_CFLAGS)
 test_zmq_LDADD = $(DEPS_LIBS) libprime_server.la
@@ -102,6 +102,9 @@ test_http_LDADD = $(DEPS_LIBS) libprime_server.la
 test_shaping_SOURCES = test/shaping.cpp
 test_shaping_CPPFLAGS = $(DEPS_CFLAGS)
 test_shaping_LDADD = $(DEPS_LIBS) libprime_server.la
+test_interrupt_SOURCES = test/interrupt.cpp
+test_interrupt_CPPFLAGS = $(DEPS_CFLAGS)
+test_interrupt_LDADD = $(DEPS_LIBS) libprime_server.la
 
 TESTS = $(check_PROGRAMS)
 TEST_EXTENSIONS = .sh

--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Build Status
 
 Grab some deps
 --------------
-    # trusty didn't have czmq in the repositories so its repackaged here
+    # trusty didn't have czmq or newer zmq in the repositories so its repackaged here
     if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then
+      sudo add-apt-repository -y ppa:kevinkreiser/libsodium
+      sudo add-apt-repository -y ppa:kevinkreiser/libpgm
+      sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
       sudo add-apt-repository -y ppa:kevinkreiser/czmq
       sudo apt-get update
     fi

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ AC_LANG_CPLUSPLUS
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 
 # check zmq version
-PKG_CHECK_MODULES([DEPS], [libzmq >= 4.0 libczmq >= 3.0 libcurl >= 7.22.0])
+PKG_CHECK_MODULES([DEPS], [libzmq >= 4.1.4 libczmq >= 3.0 libcurl >= 7.22.0])
 
 # optionally enable coverage information
 CHECK_COVERAGE

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -104,6 +104,9 @@ namespace prime_server {
     virtual void flush_stream();
     size_t size() const;
 
+    //TODO: does this really belong here!?
+    std::list<uint64_t> enqueued;
+
    protected:
     std::string log_line;
   };
@@ -141,8 +144,6 @@ namespace prime_server {
    protected:
     virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, http_request_t& request) override;
     virtual void dequeue(const std::list<zmq::message_t>& messages) override;
-   protected:
-    uint32_t request_id;
   };
 
 }

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -104,7 +104,7 @@ namespace prime_server {
     virtual void flush_stream();
     size_t size() const;
 
-    //TODO: does this really belong here!?
+    //TODO: fix this when we refactor to avoid subclassing the server
     std::list<uint64_t> enqueued;
 
    protected:

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -79,11 +79,13 @@ namespace prime_server {
     uint16_t connection_close           : 1; //header present or not
     uint16_t response_code              :10; //what the response code was set to when sent back to the client
     uint16_t spare                      : 1;
+
+    void log(size_t response_size) const;
+    bool keep_alive() const { return (version == 0 && connection_keep_alive) || (version == 1 && !connection_close); }
   };
 
-  class http_server_t;
+  class http_response_t;
   struct http_request_t : public http_entity_t {
-    friend http_server_t;
    public:
     method_t method;
     std::string path;
@@ -98,11 +100,20 @@ namespace prime_server {
     virtual std::string to_string() const;
     static std::string to_string(const method_t& method, const std::string& path, const std::string& body = "", const query_t& query = query_t{},
                                  const headers_t& headers = headers_t{}, const std::string& version = "HTTP/1.1");
+    static const zmq::message_t& timeout(http_request_info_t& info);
     static http_request_t from_string(const char* start, size_t length);
     static query_t split_path_query(std::string& path);
     std::list<http_request_t> from_stream(const char* start, size_t length, size_t max_size = std::numeric_limits<size_t>::max());
     virtual void flush_stream();
     size_t size() const;
+    void log(uint32_t id) const;
+
+    struct request_exception_t {
+      request_exception_t(const http_response_t& response);
+      void log(uint32_t id) const;
+      std::string response;
+      const uint16_t code;
+    };
 
     //TODO: fix this when we refactor to avoid subclassing the server
     std::list<uint64_t> enqueued;
@@ -135,16 +146,7 @@ namespace prime_server {
     std::string log_line;
   };
 
-  class http_server_t : public server_t<http_request_t, http_request_info_t> {
-   public:
-    http_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint,
-                  const std::string& result_endpoint, const std::string& interrupt_endpoint,
-                  bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
-    virtual ~http_server_t();
-   protected:
-    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, http_request_t& request) override;
-    virtual void dequeue(const std::list<zmq::message_t>& messages) override;
-  };
+  using http_server_t = server_t<http_request_t, http_request_info_t>;
 
 }
 

--- a/prime_server/http_util.hpp
+++ b/prime_server/http_util.hpp
@@ -25,7 +25,7 @@ namespace prime_server {
     const header_t& mime_header(const std::string& file_name, const header_t& default_mime_header = DEFAULT_MIME);
 
     //get a static file or directory listing
-    worker_t::result_t disk_result(const http_request_t& path, http_request_t::info_t& request_info,
+    worker_t::result_t disk_result(const http_request_t& path, http_request_info_t& request_info,
       const std::string& root = "./", bool allow_listing = true, size_t size_limit = 1024*1024*1024);
 
   }

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -30,15 +30,21 @@ namespace prime_server {
     netstring_entity_t response;
   };
 
-  class netstring_server_t : public server_t<netstring_entity_t, uint64_t> {
+  struct netstring_request_info_t {
+    uint32_t id;
+    uint32_t time_stamp;
+  };
+
+  class netstring_server_t : public server_t<netstring_entity_t, netstring_request_info_t> {
    public:
     netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint,
-                       const std::string& result_endpoint, bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
+                       const std::string& result_endpoint, const std::string& interrupt_endpoint,
+                       bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
     virtual ~netstring_server_t();
    protected:
-    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer);
-    virtual void dequeue(const std::list<zmq::message_t>& messages);
-    uint64_t request_id;
+    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer) override;
+    virtual void dequeue(const std::list<zmq::message_t>& messages) override;
+    uint32_t request_id;
   };
 
 }

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -9,14 +9,31 @@
 
 namespace prime_server {
 
+  struct netstring_request_info_t {
+    uint32_t id;
+    uint32_t time_stamp;
+
+    void log(size_t response_size) const;
+    bool keep_alive() const { return true; }
+  };
+
   struct netstring_entity_t {
     netstring_entity_t();
+    netstring_request_info_t to_info(uint32_t id) const;
     std::string to_string() const;
     static std::string to_string(const std::string& message);
     static netstring_entity_t from_string(const char* start, size_t length);
+    static const zmq::message_t& timeout(netstring_request_info_t& info);
     std::list<netstring_entity_t> from_stream(const char* start, size_t length, size_t max_size = std::numeric_limits<size_t>::max());
     void flush_stream();
     size_t size() const;
+    void log(uint32_t id) const;
+
+    struct request_exception_t {
+      request_exception_t(const std::string& response);
+      void log(uint32_t id) const;
+      std::string response;
+    };
 
     std::string body;
     size_t body_length;
@@ -33,21 +50,7 @@ namespace prime_server {
     netstring_entity_t response;
   };
 
-  struct netstring_request_info_t {
-    uint32_t id;
-    uint32_t time_stamp;
-  };
-
-  class netstring_server_t : public server_t<netstring_entity_t, netstring_request_info_t> {
-   public:
-    netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint,
-                       const std::string& result_endpoint, const std::string& interrupt_endpoint,
-                       bool log = false, size_t max_request_size = DEFAULT_MAX_REQUEST_SIZE);
-    virtual ~netstring_server_t();
-   protected:
-    virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer) override;
-    virtual void dequeue(const std::list<zmq::message_t>& messages) override;
-  };
+  using netstring_server_t = server_t<netstring_entity_t, netstring_request_info_t>;
 
 }
 

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -21,7 +21,7 @@ namespace prime_server {
     std::string body;
     size_t body_length;
 
-    //TODO: does this really belong here!?
+    //TODO: fix this when we refactor to avoid subclassing the server
     std::list<uint64_t> enqueued;
   };
 

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -20,6 +20,9 @@ namespace prime_server {
 
     std::string body;
     size_t body_length;
+
+    //TODO: does this really belong here!?
+    std::list<uint64_t> enqueued;
   };
 
   class netstring_client_t : public client_t {
@@ -44,7 +47,6 @@ namespace prime_server {
    protected:
     virtual bool enqueue(const zmq::message_t& requester, const zmq::message_t& message, netstring_entity_t& buffer) override;
     virtual void dequeue(const std::list<zmq::message_t>& messages) override;
-    uint32_t request_id;
   };
 
 }

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -107,7 +107,7 @@ namespace prime_server {
     std::unordered_map<zmq::message_t, request_container_t> sessions;
     //a record of what requests we have in progress
     //TODO: keep time of request and kill requests that stick around for a long time
-    std::unordered_map<uint32_t, zmq::message_t> requests;
+    std::unordered_map<uint64_t, zmq::message_t> requests;
     uint32_t request_id;
   };
 
@@ -171,6 +171,7 @@ namespace prime_server {
     std::string heart_beat;
     uint64_t job;
     std::unordered_set<uint64_t> interrupts;
+    std::list<uint64_t> interrupt_history;
   };
 
 }

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -13,7 +13,6 @@
 #include <utility>
 #include <type_traits>
 #include <cstdint>
-#include <ctime>
 
 #include <prime_server/zmq_helpers.hpp>
 

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -81,11 +81,8 @@ namespace prime_server {
     //  log the response if log == true
     virtual void dequeue(const std::list<zmq::message_t>& messages) = 0;
 
-    //TODO: refactor enqueue/dequeue. into something like a session_t object that could
-    //do the protocol specific enqueueing and dequeueing. the interfaces are very close
-    //already and the things they do for both protocols are pretty similar. it would be
-    //nice to make a single object handle these bits rather than subclassing the server
-    //maybe we can just add functionality to the *_entity_t objects in the protcols?
+    //TODO: refactor enqueue/dequeue to be part of the request_container_t implementation
+    //this will allow us to avoid subclassing the server (which is not desirable)
 
     //contractual obligations for supplying your own request_info_t, the last 2 are strict for the purposes
     //of possibly allowing the proxy to easily peak at the request id without knowing the server protocol

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -3,7 +3,7 @@
 
 //some version info
 #define PRIME_SERVER_VERSION_MAJOR 0
-#define PRIME_SERVER_VERSION_MINOR 5
+#define PRIME_SERVER_VERSION_MINOR 6
 #define PRIME_SERVER_VERSION_PATCH 0
 
 #include <functional>

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -282,7 +282,7 @@ namespace prime_server {
     auto connection_header = headers.find("Connection");
     return http_request_info_t {
       id,
-      static_cast<uint32_t>(difftime(time(nullptr), static_cast<time_t>(0)) + .5),
+      static_cast<uint32_t>(difftime(time(nullptr), 0) + .5),
       static_cast<uint16_t>(version == "HTTP/1.0" ? 0 : 1),
       static_cast<uint16_t>(connection_header != headers.end() && connection_header->second == "Keep-Alive"),
       static_cast<uint16_t>(connection_header != headers.end() && connection_header->second == "Close")
@@ -676,14 +676,14 @@ namespace prime_server {
         log_request(info.id, parsed_request.log_line);
       //remember we are working on it
       request.enqueued.emplace_back(*static_cast<uint64_t*>(static_cast<void*>(&info)));
-      this->requests.emplace(info.id, requester);
+      this->requests.emplace(request.enqueued.back(), requester);
     }
     return true;
   }
   void http_server_t::dequeue(const std::list<zmq::message_t>& messages) {
     //find the request
     const auto& info = *static_cast<const http_request_info_t*>(messages.front().data());
-    auto request = requests.find(info.id);
+    auto request = requests.find(*static_cast<const uint64_t*>(static_cast<const void*>(messages.front().data())));
     if(request == requests.end()) {
       logging::WARN("Unknown or timed-out request id: " + std::to_string(info.id));
       return;

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -2,6 +2,7 @@
 #include "logging.hpp"
 
 #include <curl/curl.h>
+#include <ctime>
 
 //TODO: someone please replace the http protocol, its a giant mess. kthxbye
 
@@ -281,7 +282,7 @@ namespace prime_server {
     auto connection_header = headers.find("Connection");
     return http_request_info_t {
       id,
-      0,
+      static_cast<uint32_t>(difftime(time(nullptr), static_cast<time_t>(0)) + .5),
       static_cast<uint16_t>(version == "HTTP/1.0" ? 0 : 1),
       static_cast<uint16_t>(connection_header != headers.end() && connection_header->second == "Keep-Alive"),
       static_cast<uint16_t>(connection_header != headers.end() && connection_header->second == "Close")

--- a/src/http_util.cpp
+++ b/src/http_util.cpp
@@ -53,7 +53,7 @@ namespace prime_server {
       return header->second;
     }
 
-    worker_t::result_t disk_result(const http_request_t& request, http_request_t::info_t& request_info, const std::string& root, bool allow_listing, size_t size_limit) {
+    worker_t::result_t disk_result(const http_request_t& request, http_request_info_t& request_info, const std::string& root, bool allow_listing, size_t size_limit) {
       worker_t::result_t result{false};
       //get the canonical path
       auto path = request.path;

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -123,7 +123,7 @@ namespace prime_server {
   netstring_server_t::netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint,
                                          const std::string& result_endpoint, const std::string& interrupt_endpoint, bool log, size_t max_request_size):
                                          server_t<netstring_entity_t, netstring_request_info_t>::server_t(context, client_endpoint, proxy_endpoint,
-                                         result_endpoint, interrupt_endpoint, log, max_request_size), request_id(0) {
+                                         result_endpoint, interrupt_endpoint, log, max_request_size) {
   }
 
   netstring_server_t::~netstring_server_t(){}
@@ -142,7 +142,7 @@ namespace prime_server {
         log_transaction(request_id, "REPLIED");
       }
       ++request_id;
-      return true;
+      return false;
     }
 
     //send on each request
@@ -153,6 +153,7 @@ namespace prime_server {
       if(log)
         log_transaction(request_id, request.body);
       //remember we are working on it
+      request.enqueued.emplace_back(*static_cast<uint64_t*>(static_cast<void*>(&info)));
       this->requests.emplace(info.id, requester);
     }
     return true;

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -3,6 +3,7 @@
 
 #include <cctype>
 #include <cstdlib>
+#include <ctime>
 
 namespace {
 
@@ -146,7 +147,7 @@ namespace prime_server {
 
     //send on each request
     for(const auto& parsed_request : parsed_requests) {
-      netstring_request_info_t info{request_id};
+      netstring_request_info_t info{request_id, static_cast<uint32_t>(difftime(time(nullptr), static_cast<time_t>(0)) + .5)};
       this->proxy.send(static_cast<const void*>(&info), sizeof(netstring_request_info_t), ZMQ_DONTWAIT | ZMQ_SNDMORE);
       this->proxy.send(parsed_request.to_string(), ZMQ_DONTWAIT);
       if(log)

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -119,8 +119,10 @@ namespace prime_server {
     return responses.size();
   }
 
-  netstring_server_t::netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint, const std::string& result_endpoint, bool log, size_t max_request_size):
-    server_t<netstring_entity_t, uint64_t>::server_t(context, client_endpoint, proxy_endpoint, result_endpoint, log, max_request_size), request_id(0) {
+  netstring_server_t::netstring_server_t(zmq::context_t& context, const std::string& client_endpoint, const std::string& proxy_endpoint,
+                                         const std::string& result_endpoint, const std::string& interrupt_endpoint, bool log, size_t max_request_size):
+                                         server_t<netstring_entity_t, netstring_request_info_t>::server_t(context, client_endpoint, proxy_endpoint,
+                                         result_endpoint, interrupt_endpoint, log, max_request_size), request_id(0) {
   }
 
   netstring_server_t::~netstring_server_t(){}
@@ -144,7 +146,8 @@ namespace prime_server {
 
     //send on each request
     for(const auto& parsed_request : parsed_requests) {
-      this->proxy.send(static_cast<const void*>(&request_id), sizeof(request_id), ZMQ_DONTWAIT | ZMQ_SNDMORE);
+      netstring_request_info_t info{request_id};
+      this->proxy.send(static_cast<const void*>(&info), sizeof(netstring_request_info_t), ZMQ_DONTWAIT | ZMQ_SNDMORE);
       this->proxy.send(parsed_request.to_string(), ZMQ_DONTWAIT);
       if(log)
         log_transaction(request_id, request.body);

--- a/src/prime_echod.cpp
+++ b/src/prime_echod.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
   for(size_t i = 0; i < worker_concurrency; ++i) {
     echo_worker_threads.emplace_back(std::bind(&worker_t::work,
       worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint, request_interrupt,
-      [] (const std::list<zmq::message_t>& job, void* request_info) {
+      [] (const std::list<zmq::message_t>& job, void* request_info, worker_t::interrupt_function_t&) {
         worker_t::result_t result{false};
         try {
           //echo

--- a/src/prime_echod.cpp
+++ b/src/prime_echod.cpp
@@ -35,11 +35,12 @@ int main(int argc, char** argv) {
   //change these to tcp://known.ip.address.with:port if you want to do this across machines
   zmq::context_t context;
   std::string result_endpoint = "ipc:///tmp/result_endpoint";
+  std::string request_interrupt = "ipc://request_interrupt";
   std::string proxy_endpoint = "ipc:///tmp/proxy_endpoint";
 
   //server
   std::thread server_thread = std::thread(std::bind(&http_server_t::serve,
-    http_server_t(context, server_endpoint, proxy_endpoint + "_upstream", result_endpoint, true)));
+    http_server_t(context, server_endpoint, proxy_endpoint + "_upstream", result_endpoint, request_interrupt, true)));
 
   //load balancer for parsing
   std::thread echo_proxy(std::bind(&proxy_t::forward, proxy_t(context, proxy_endpoint + "_upstream", proxy_endpoint + "_downstream")));
@@ -49,19 +50,19 @@ int main(int argc, char** argv) {
   std::list<std::thread> echo_worker_threads;
   for(size_t i = 0; i < worker_concurrency; ++i) {
     echo_worker_threads.emplace_back(std::bind(&worker_t::work,
-      worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint,
+      worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint, request_interrupt,
       [] (const std::list<zmq::message_t>& job, void* request_info) {
         worker_t::result_t result{false};
         try {
           //echo
           http_response_t response(200, "OK", std::string(static_cast<const char*>(job.front().data()), job.front().size()));
-          response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+          response.from_info(*static_cast<http_request_info_t*>(request_info));
           result.messages = {response.to_string()};
         }
         catch(const std::exception& e) {
           //complain
           http_response_t response(400, "Bad Request", e.what());
-          response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+          response.from_info(*static_cast<http_request_info_t*>(request_info));
           result.messages = {response.to_string()};
         }
         return result;

--- a/src/prime_filed.cpp
+++ b/src/prime_filed.cpp
@@ -16,7 +16,7 @@ using namespace prime_server;
 
 std::string root = "./";
 
-worker_t::result_t disk_work(const std::list<zmq::message_t>& job, void* request_info) {
+worker_t::result_t disk_work(const std::list<zmq::message_t>& job, void* request_info, worker_t::interrupt_function_t&) {
   worker_t::result_t result{false};
   try {
     //check the disk
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
   //file serving thread
   std::thread file_worker(std::bind(&worker_t::work,
     worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint, request_interrupt,
-    std::bind(&disk_work, std::placeholders::_1, std::placeholders::_2)
+    std::bind(&disk_work, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)
   )));
   file_worker.detach();
 

--- a/src/prime_filed.cpp
+++ b/src/prime_filed.cpp
@@ -21,11 +21,11 @@ worker_t::result_t disk_work(const std::list<zmq::message_t>& job, void* request
   try {
     //check the disk
     auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
-    return http::disk_result(request, *static_cast<http_request_t::info_t*>(request_info), root);
+    return http::disk_result(request, *static_cast<http_request_info_t*>(request_info), root);
   }
   catch(const std::exception& e) {
     http_response_t response(400, "Bad Request", e.what());
-    response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+    response.from_info(*static_cast<http_request_info_t*>(request_info));
     result.messages = {response.to_string()};
   }
   return result;
@@ -51,11 +51,12 @@ int main(int argc, char** argv) {
   //change these to tcp://known.ip.address.with:port if you want to do this across machines
   zmq::context_t context;
   std::string result_endpoint = "ipc://result_endpoint";
+  std::string request_interrupt = "ipc://request_interrupt";
   std::string proxy_endpoint = "ipc://proxy_endpoint";
 
   //server
   std::thread server = std::thread(std::bind(&http_server_t::serve,
-    http_server_t(context, server_endpoint, proxy_endpoint + "_upstream", result_endpoint, true)));
+    http_server_t(context, server_endpoint, proxy_endpoint + "_upstream", result_endpoint, request_interrupt, true)));
 
   //load balancer for file serving
   std::thread file_proxy(std::bind(&proxy_t::forward, proxy_t(context, proxy_endpoint + "_upstream", proxy_endpoint + "_downstream")));
@@ -63,7 +64,7 @@ int main(int argc, char** argv) {
 
   //file serving thread
   std::thread file_worker(std::bind(&worker_t::work,
-    worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint,
+    worker_t(context, proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint, request_interrupt,
     std::bind(&disk_work, std::placeholders::_1, std::placeholders::_2)
   )));
   file_worker.detach();

--- a/src/prime_httpd.cpp
+++ b/src/prime_httpd.cpp
@@ -5,9 +5,9 @@ using namespace prime_server;
 
 int main(int argc, char** argv) {
 
-  if(argc < 4) {
+  if(argc < 5) {
     logging::ERROR("Usage: " + std::string(argv[0]) +
-      " [tcp|ipc]://server_listen_endpoint[:tcp_port] [tcp|ipc]://downstream_proxy_endpoint[:tcp_port] [tcp|ipc]://server_result_loopback[:tcp_port]");
+      " [tcp|ipc]://server_listen_endpoint[:tcp_port] [tcp|ipc]://downstream_proxy_endpoint[:tcp_port] [tcp|ipc]://server_result_loopback[:tcp_port] [tcp|ipc]://server_request_interrupt[:tcp_port]");
     return EXIT_FAILURE;
   }
 
@@ -15,16 +15,19 @@ int main(int argc, char** argv) {
   std::string server_endpoint(argv[1]);
   std::string proxy_endpoint(argv[2]);
   std::string server_result_loopback(argv[3]);
+  std::string server_request_interrupt(argv[4]);
   if(server_endpoint.find("://") != 3)
     logging::ERROR("bad server listen endpoint");
   if(proxy_endpoint.find("://") != 3)
     logging::ERROR("bad downstream proxy endpoint");
   if(server_result_loopback.find("://") != 3)
     logging::ERROR("bad server result loopback");
+  if(server_request_interrupt.find("://") != 3)
+    logging::ERROR("bad server request interrupt");
 
   //start it up
   zmq::context_t context;
-  http_server_t server(context, server_endpoint, proxy_endpoint, server_result_loopback, true);
+  http_server_t server(context, server_endpoint, proxy_endpoint, server_result_loopback, server_request_interrupt, true);
 
   //TODO: catch SIGINT for graceful shutdown
   server.serve();

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -40,7 +40,7 @@ namespace prime_server {
     size_t identity_size = sizeof(identity);
     server.getsockopt(ZMQ_IDENTITY, identity, &identity_size);
 
-    bool more = false;
+    bool more = true;
     do {
       //request some
       size_t current_batch = 0;
@@ -61,7 +61,7 @@ namespace prime_server {
 
       //receive some
       current_batch = 0;
-      while(current_batch < batch_size) {
+      while(more && current_batch < batch_size) {
         try {
           //see if we are still waiting for stuff
           auto messages = server.recv_all(0);

--- a/src/prime_serverd.cpp
+++ b/src/prime_serverd.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv) {
   for(size_t i = 0; i < worker_concurrency; ++i) {
     parse_worker_threads.emplace_back(std::bind(&worker_t::work,
       worker_t(context, parse_proxy_endpoint + "_downstream", compute_proxy_endpoint + "_upstream", result_endpoint, request_interrupt,
-      [] (const std::list<zmq::message_t>& job, void* request_info) {
+      [] (const std::list<zmq::message_t>& job, void* request_info, worker_t::interrupt_function_t& interrupt) {
         //request should look like
         ///is_prime?possible_prime=SOME_NUMBER
         try{
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
   for(size_t i = 0; i < worker_concurrency; ++i) {
     compute_worker_threads.emplace_back(std::bind(&worker_t::work,
       worker_t(context, compute_proxy_endpoint + "_downstream", "ipc:///dev/null", result_endpoint, request_interrupt,
-      [] (const std::list<zmq::message_t>& job, void* request_info) {
+      [] (const std::list<zmq::message_t>& job, void* request_info, worker_t::interrupt_function_t&) {
         //check if its prime
         size_t prime = *static_cast<const size_t*>(job.front().data());
         size_t divisor = 2;

--- a/src/prime_workerd.cpp
+++ b/src/prime_workerd.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
   //start it up
   zmq::context_t context;
   worker_t worker(context, upstream_proxy_endpoint, downstream_proxy_endpoint, server_result_loopback, server_request_interrupt,
-    [](const std::list<zmq::message_t>& messages, void* request_info){
+    [](const std::list<zmq::message_t>& messages, void* request_info, worker_t::interrupt_function_t&){
       auto request = http_request_t::from_string(static_cast<const char*>(messages.front().data()), messages.front().size());
 
       worker_t::result_t result{false};

--- a/src/prime_workerd.cpp
+++ b/src/prime_workerd.cpp
@@ -9,9 +9,9 @@ using namespace prime_server;
 
 int main(int argc, char** argv) {
 
-  if(argc < 4) {
+  if(argc < 5) {
     logging::ERROR("Usage: " + std::string(argv[0]) +
-      " [tcp|ipc]://upstream_proxy_endpoint[:tcp_port] [tcp|ipc]://downstream_proxy_endpoint[:tcp_port] [tcp|ipc]://server_result_loopback[:tcp_port]");
+      " [tcp|ipc]://upstream_proxy_endpoint[:tcp_port] [tcp|ipc]://downstream_proxy_endpoint[:tcp_port] [tcp|ipc]://server_result_loopback[:tcp_port] [tcp|ipc]://server_request_interrupt[:tcp_port]");
     return EXIT_FAILURE;
   }
 
@@ -19,16 +19,19 @@ int main(int argc, char** argv) {
   std::string upstream_proxy_endpoint(argv[1]);
   std::string downstream_proxy_endpoint(argv[2]);
   std::string server_result_loopback(argv[3]);
+  std::string server_request_interrupt(argv[4]);
   if(upstream_proxy_endpoint.find("://") != 3)
     logging::ERROR("bad upstream proxy endpoint");
   if(downstream_proxy_endpoint.find("://") != 3)
     logging::ERROR("bad downstream proxy endpoint");
   if(server_result_loopback.find("://") != 3)
     logging::ERROR("bad server result loopback");
+  if(server_request_interrupt.find("://") != 3)
+    logging::ERROR("bad server request interrupt");
 
   //start it up
   zmq::context_t context;
-  worker_t worker(context, upstream_proxy_endpoint, downstream_proxy_endpoint, server_result_loopback,
+  worker_t worker(context, upstream_proxy_endpoint, downstream_proxy_endpoint, server_result_loopback, server_request_interrupt,
     [](const std::list<zmq::message_t>& messages, void* request_info){
       auto request = http_request_t::from_string(static_cast<const char*>(messages.front().data()), messages.front().size());
 
@@ -51,12 +54,12 @@ int main(int argc, char** argv) {
         body.assign((std::istreambuf_iterator<char>(stream)), std::istreambuf_iterator<char>());
 
         http_response_t response(200, "OK", body);
-        response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+        response.from_info(*static_cast<http_request_info_t*>(request_info));
         result.messages.emplace_back(response.to_string());
       }
       catch(...) {
         http_response_t response(404, "Not Found");
-        response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+        response.from_info(*static_cast<http_request_info_t*>(request_info));
         result.messages.emplace_back(response.to_string());
       }
       return result;

--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -2,7 +2,6 @@
 #include <czmq.h>
 #include <ctime>
 #include <arpa/inet.h>
-#include <chrono>
 #include <random>
 
 namespace {
@@ -186,7 +185,7 @@ namespace zmq {
         throw std::runtime_error("Beacon not supported");
       //keep the socket for polling
       socket = zsock_resolve(zactor_sock(actor.get()));
-      generator.seed(std::chrono::system_clock::now().time_since_epoch().count());
+      generator.seed(std::time(nullptr));
     }
     ~cheshire_cat_t(){}
     std::string rand_uuid(size_t size){
@@ -321,7 +320,7 @@ namespace zmq {
 
   //make a random port in suggested range
   uint16_t random_port() {
-    std::default_random_engine generator(std::chrono::system_clock::now().time_since_epoch().count());
+    std::default_random_engine generator(std::time(nullptr));
     std::uniform_int_distribution<uint16_t> distribution(49152, 65535);
     return distribution(generator);
   }

--- a/src/zmq_helpers.cpp
+++ b/src/zmq_helpers.cpp
@@ -488,9 +488,9 @@ namespace murmur_hash3 {
   }
 
   //let the compiler pick which hash makes sense for your architecture
-  template<int> size_t specialized_hash_bytes(const void*, size_t);
-  template<> size_t specialized_hash_bytes<4>(const void* bytes, size_t length) { return murmur_hash3_x86_32(bytes, length, 1); }
-  template<> size_t specialized_hash_bytes<8>(const void* bytes, size_t length) { return murmur_hash3_x64_128(bytes, length, 1); }
+  template<int> inline size_t specialized_hash_bytes(const void*, size_t);
+  template<> inline size_t specialized_hash_bytes<4>(const void* bytes, size_t length) { return murmur_hash3_x86_32(bytes, length, 1); }
+  template<> inline size_t specialized_hash_bytes<8>(const void* bytes, size_t length) { return murmur_hash3_x64_128(bytes, length, 1); }
   inline size_t hash_bytes(const void* bytes, size_t length) { return specialized_hash_bytes<sizeof(size_t)>(bytes, length); }
 }
 

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -286,7 +286,7 @@ namespace {
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
       worker_t(context, "ipc:///tmp/test_http_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_http_results", "ipc:///tmp/test_http_interrupt",
-      [] (const std::list<zmq::message_t>& job, void* request_info) {
+      [] (const std::list<zmq::message_t>& job, void* request_info, worker_t::interrupt_function_t&) {
         //could be a get or a post
         auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
         http_response_t response(200, "OK");

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -48,7 +48,7 @@ namespace {
 
   void test_streaming_server() {
     zmq::context_t context;
-    testable_http_server_t server(context, "ipc:///tmp/test_http_server", "ipc:///tmp/test_http_proxy_upstream", "ipc:///tmp/test_http_results");
+    testable_http_server_t server(context, "ipc:///tmp/test_http_server", "ipc:///tmp/test_http_proxy_upstream", "ipc:///tmp/test_http_results", "ipc:///tmp/test_http_interrupt");
     server.passify();
 
     testable_http_request_t request;
@@ -129,8 +129,6 @@ namespace {
       throw std::runtime_error("Request parsing failed");
     if(request.to_info(0).connection_keep_alive != 0)
       throw std::runtime_error("Request parsing failed");
-    if(request.to_info(0).do_not_track != 0)
-      throw std::runtime_error("Request parsing failed");
 
     request_str = "GET /blah HTTP/1.0\r\nHost: *\r\nContent-Length: 5\r\nDNT: 0\r\nConnection: Close\r\nUser-Agent: fake-agent\r\n\r\nhello";
     request = http_request_t::from_string(request_str.c_str(), request_str.size());
@@ -144,8 +142,6 @@ namespace {
       throw std::runtime_error("Request parsing failed");
     if(request.to_info(0).connection_keep_alive != 0)
       throw std::runtime_error("Request parsing failed");
-    if(request.to_info(0).do_not_track != 0)
-      throw std::runtime_error("Request parsing failed");
 
     request_str = "POST /is_prime HTTP/1.1\r\nPragma: no-cache\r\nDNT: 1\r\nConnection: Keep-Alive\r\nContent-Type: text/xml; charset=UTF-8\r\nAccept-Encoding: gzip, deflate\r\nAccept-Language: de,en-US;q=0.7,en;q=0.3\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\nUser-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:35.0) Gecko/20100101 Firefox/35.0\r\nCache-Control: no-cache\r\nContent-Length: 11\r\nHost: localhost:8002\r\n\r\n32416190071";
     request = http_request_t::from_string(request_str.c_str(), request_str.size());
@@ -156,8 +152,6 @@ namespace {
     if(request.to_info(0).connection_close != 0)
       throw std::runtime_error("Request parsing failed");
     if(request.to_info(0).connection_keep_alive != 1)
-      throw std::runtime_error("Request parsing failed");
-    if(request.to_info(0).do_not_track != 1)
       throw std::runtime_error("Request parsing failed");
   }
 
@@ -281,7 +275,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&http_server_t::serve,
-     http_server_t(context, "ipc:///tmp/test_http_server", "ipc:///tmp/test_http_proxy_upstream", "ipc:///tmp/test_http_results", false, MAX_REQUEST_SIZE)));
+     http_server_t(context, "ipc:///tmp/test_http_server", "ipc:///tmp/test_http_proxy_upstream", "ipc:///tmp/test_http_results", "ipc:///tmp/test_http_interrupt", false, MAX_REQUEST_SIZE)));
     server.detach();
 
     //load balancer for parsing
@@ -291,7 +285,7 @@ namespace {
 
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
-      worker_t(context, "ipc:///tmp/test_http_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_http_results",
+      worker_t(context, "ipc:///tmp/test_http_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_http_results", "ipc:///tmp/test_http_interrupt",
       [] (const std::list<zmq::message_t>& job, void* request_info) {
         //could be a get or a post
         auto request = http_request_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
@@ -302,7 +296,7 @@ namespace {
           response.body = request.path;
         else
           throw std::runtime_error("Wrong method, get or post expected");
-        response.from_info(*static_cast<http_request_t::info_t*>(request_info));
+        response.from_info(*static_cast<http_request_info_t*>(request_info));
 
         //send it back
         worker_t::result_t result{false};

--- a/test/interrupt.cpp
+++ b/test/interrupt.cpp
@@ -89,7 +89,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", false, DEFAULT_MAX_REQUEST_SIZE, 1)));
+      netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", false)));
     server.detach();
 
     //we want a client that is very fickle, we need the client to send a request and then bail right away before
@@ -135,7 +135,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_timeout_server", "ipc:///tmp/test_timeout_proxy_upstream", "ipc:///tmp/test_timeout_results", "ipc:///tmp/test_timeout_interrupt", false)));
+      netstring_server_t(context, "ipc:///tmp/test_timeout_server", "ipc:///tmp/test_timeout_proxy_upstream", "ipc:///tmp/test_timeout_results", "ipc:///tmp/test_timeout_interrupt", false, DEFAULT_MAX_REQUEST_SIZE, 1)));
     server.detach();
 
     //load balancer
@@ -152,9 +152,8 @@ namespace {
     worker.detach();
 
     std::string request = netstring_entity_t::to_string("wart uf mi");
-    testable_client_t* client;
-    client = new testable_client_t(context, "ipc:///tmp/test_timeout_server",
-      [&request, &client]() {
+    testable_client_t client(context, "ipc:///tmp/test_timeout_server",
+      [&request]() {
         return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
       },
       [](const void* data, size_t size) {
@@ -163,7 +162,7 @@ namespace {
           throw std::runtime_error("Expected TIMEOUT response!");
         return false;
       }, 1);
-    client->batch();
+    client.batch();
   }
 
 }

--- a/test/interrupt.cpp
+++ b/test/interrupt.cpp
@@ -1,0 +1,142 @@
+#include "testing/testing.hpp"
+#include "prime_server.hpp"
+#include "netstring_protocol.hpp"
+
+#include <unistd.h>
+#include <functional>
+#include <memory>
+#include <unordered_set>
+#include <thread>
+#include <iterator>
+#include <cstdlib>
+#include <cstring>
+#include <condition_variable>
+#include <mutex>
+
+using namespace prime_server;
+
+namespace {
+
+  class testable_client_t : public netstring_client_t {
+   public:
+    using netstring_client_t::netstring_client_t;
+    using netstring_client_t::batch_size;
+  };
+
+
+  //this has to catch an interrupt or we'll wait forever
+  std::mutex mutex;
+  std::condition_variable condition;
+  class testable_worker_t : public worker_t {
+   public:
+    using worker_t::worker_t;
+   protected:
+    virtual void cancel(bool check_previous) override {
+      std::unique_lock<std::mutex> lock(mutex);
+      try { worker_t::cancel(check_previous); }
+      catch (...) { condition.notify_one(); }
+    }
+  };
+
+  void test_early() {
+    zmq::context_t context;
+
+    //server
+    std::thread server(std::bind(&netstring_server_t::serve,
+      netstring_server_t(context, "ipc:///tmp/test_early_server", "ipc:///tmp/test_early_proxy_upstream", "ipc:///tmp/test_early_results", "ipc:///tmp/test_early_interrupt", false)));
+    server.detach();
+
+    //we want a client that is very fickle, we need the client to send a request and then bail right away before
+    //clients always work in batch mode which is to say they send n requests and then wait for n responses. to trick
+    //the client into hanging up without a response we've made it so that the act of making a request sets the expected
+    //number of responses to 0. this will skip the loop that tries to collect n responses because it thinks it needs 0
+    {
+      std::string request = netstring_entity_t::to_string("nei, will i noed");
+      testable_client_t* client;
+      client = new testable_client_t(context, "ipc:///tmp/test_early_server",
+        [&request, &client]() {
+        client->batch_size = 0;
+          return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
+        },
+        [](const void* data, size_t size) { return false; }, 1);
+      client->batch();
+    }
+
+    //load balancer
+    std::thread proxy(std::bind(&proxy_t::forward, proxy_t(context, "ipc:///tmp/test_early_proxy_upstream", "ipc:///tmp/test_early_proxy_downstream")));
+    proxy.detach();
+
+    //busy worker
+    std::thread worker(std::bind(&testable_worker_t::work,
+      testable_worker_t(context, "ipc:///tmp/test_early_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_early_results", "ipc:///tmp/test_early_interrupt",
+      [] (const std::list<zmq::message_t>& job, void*) {
+        while(true);
+        return worker_t::result_t{false, {netstring_entity_t::to_string("i schteck fescht")}};
+      })));
+    worker.detach();
+
+    //wait to get the signal that it was intercepted
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock);
+  }
+
+  void test_loop() {
+    zmq::context_t context;
+
+    //server
+    std::thread server(std::bind(&netstring_server_t::serve,
+      netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", false)));
+    server.detach();
+
+    //we want a client that is very fickle, we need the client to send a request and then bail right away before
+    //clients always work in batch mode which is to say they send n requests and then wait for n responses. to trick
+    //the client into hanging up without a response we've made it so that the act of making a request sets the expected
+    //number of responses to 0. this will skip the loop that tries to collect n responses because it thinks it needs 0
+    std::string request = netstring_entity_t::to_string("nei, will i noed");
+    testable_client_t* client;
+    client = new testable_client_t(context, "ipc:///tmp/test_loop_server",
+      [&request, &client]() {
+      client->batch_size = 0;
+        return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
+      },
+      [](const void* data, size_t size) { return false; }, 1);
+    client->batch();
+
+    //load balancer
+    std::thread proxy(std::bind(&proxy_t::forward, proxy_t(context, "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_proxy_downstream")));
+    proxy.detach();
+
+    //busy worker
+    std::thread worker(std::bind(&worker_t::work,
+      worker_t(context, "ipc:///tmp/test_loop_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt",
+      [] (const std::list<zmq::message_t>& job, void*) {
+        condition.notify_one();
+        while(true) {
+          try { /*cancel();*/ }
+          catch (...) { condition.notify_one(); }
+        }
+        return worker_t::result_t{false, {netstring_entity_t::to_string("i schteck fescht")}};
+      })));
+    worker.detach();
+
+    //wait for notify of working, send the cancel, wait for cancel
+    std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock);
+    delete client;
+    condition.wait(lock);
+  }
+
+}
+
+int main() {
+  //make this whole thing bail if it doesnt finish fast
+  alarm(10);
+
+  testing::suite suite("interrupt");
+
+  suite.test(TEST_CASE(test_early));
+
+  suite.test(TEST_CASE(test_loop));
+
+  return suite.tear_down();
+}

--- a/test/interrupt.cpp
+++ b/test/interrupt.cpp
@@ -16,6 +16,9 @@
 using namespace prime_server;
 
 namespace {
+  //use these to manipulate flow control
+  std::mutex mutex;
+  std::condition_variable condition;
 
   class testable_client_t : public netstring_client_t {
    public:
@@ -23,17 +26,18 @@ namespace {
     using netstring_client_t::batch_size;
   };
 
-
   //this has to catch an interrupt or we'll wait forever
-  std::mutex mutex;
-  std::condition_variable condition;
   class testable_worker_t : public worker_t {
    public:
     using worker_t::worker_t;
    protected:
-    virtual void cancel(bool check_previous) override {
+    virtual void handle_interrupt(bool force_check) override {
       std::unique_lock<std::mutex> lock(mutex);
-      try { worker_t::cancel(check_previous); }
+      condition.notify_one();
+      condition.wait(lock);
+      //I dont like doing this but... with pub sub delivery isnt gauranteed so its best to wait around
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      try { worker_t::handle_interrupt(force_check); }
       catch (...) { condition.notify_one(); }
     }
   };
@@ -46,22 +50,6 @@ namespace {
       netstring_server_t(context, "ipc:///tmp/test_early_server", "ipc:///tmp/test_early_proxy_upstream", "ipc:///tmp/test_early_results", "ipc:///tmp/test_early_interrupt", false)));
     server.detach();
 
-    //we want a client that is very fickle, we need the client to send a request and then bail right away before
-    //clients always work in batch mode which is to say they send n requests and then wait for n responses. to trick
-    //the client into hanging up without a response we've made it so that the act of making a request sets the expected
-    //number of responses to 0. this will skip the loop that tries to collect n responses because it thinks it needs 0
-    {
-      std::string request = netstring_entity_t::to_string("nei, will i noed");
-      testable_client_t* client;
-      client = new testable_client_t(context, "ipc:///tmp/test_early_server",
-        [&request, &client]() {
-        client->batch_size = 0;
-          return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
-        },
-        [](const void* data, size_t size) { return false; }, 1);
-      client->batch();
-    }
-
     //load balancer
     std::thread proxy(std::bind(&proxy_t::forward, proxy_t(context, "ipc:///tmp/test_early_proxy_upstream", "ipc:///tmp/test_early_proxy_downstream")));
     proxy.detach();
@@ -69,14 +57,30 @@ namespace {
     //busy worker
     std::thread worker(std::bind(&testable_worker_t::work,
       testable_worker_t(context, "ipc:///tmp/test_early_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_early_results", "ipc:///tmp/test_early_interrupt",
-      [] (const std::list<zmq::message_t>& job, void*) {
+      [] (const std::list<zmq::message_t>& job, void*, worker_t::interrupt_function_t&) {
         while(true);
         return worker_t::result_t{false, {netstring_entity_t::to_string("i schteck fescht")}};
       })));
     worker.detach();
 
-    //wait to get the signal that it was intercepted
+    //we want a client that is very fickle, we need the client to send a request and then bail right away before
+    //clients always work in batch mode which is to say they send n requests and then wait for n responses. to trick
+    //the client into hanging up without a response we've made it so that the act of making a request sets the expected
+    //number of responses to 0. this will skip the loop that tries to collect n responses because it thinks it needs 0
+    std::string request = netstring_entity_t::to_string("nei, will i noed");
+    testable_client_t* client = new testable_client_t(context, "ipc:///tmp/test_early_server",
+      [&request, &client]() {
+        client->batch_size = 0;
+        return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
+      },
+      [](const void* data, size_t size) { return false; }, 1);
+    client->batch();
+
+    //wait for job, disconnect, wait for cancel
     std::unique_lock<std::mutex> lock(mutex);
+    condition.wait(lock);
+    delete client;
+    condition.notify_one();
     condition.wait(lock);
   }
 
@@ -85,7 +89,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", false)));
+      netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", true)));
     server.detach();
 
     //we want a client that is very fickle, we need the client to send a request and then bail right away before
@@ -96,7 +100,7 @@ namespace {
     testable_client_t* client;
     client = new testable_client_t(context, "ipc:///tmp/test_loop_server",
       [&request, &client]() {
-      client->batch_size = 0;
+        client->batch_size = 0;
         return std::make_pair(static_cast<const void*>(request.c_str()), request.size());
       },
       [](const void* data, size_t size) { return false; }, 1);
@@ -109,10 +113,10 @@ namespace {
     //busy worker
     std::thread worker(std::bind(&worker_t::work,
       worker_t(context, "ipc:///tmp/test_loop_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt",
-      [] (const std::list<zmq::message_t>& job, void*) {
+      [] (const std::list<zmq::message_t>& job, void*, worker_t::interrupt_function_t& interrupt) {
         condition.notify_one();
         while(true) {
-          try { /*cancel();*/ }
+          try { interrupt(); }
           catch (...) { condition.notify_one(); }
         }
         return worker_t::result_t{false, {netstring_entity_t::to_string("i schteck fescht")}};
@@ -130,7 +134,7 @@ namespace {
 
 int main() {
   //make this whole thing bail if it doesnt finish fast
-  alarm(10);
+  alarm(60);
 
   testing::suite suite("interrupt");
 

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -43,7 +43,7 @@ namespace {
 
   void test_streaming_server() {
     zmq::context_t context;
-    testable_netstring_server_t server(context, "ipc:///tmp/test_netstring_server", "ipc:///tmp/test_netstring_proxy_upstream", "ipc:///tmp/test_netstring_results");
+    testable_netstring_server_t server(context, "ipc:///tmp/test_netstring_server", "ipc:///tmp/test_netstring_proxy_upstream", "ipc:///tmp/test_netstring_results", "ipc:///tmp/test_netstring_interrupt");
     server.passify();
 
     netstring_entity_t request;
@@ -149,7 +149,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_netstring_server", "ipc:///tmp/test_netstring_proxy_upstream", "ipc:///tmp/test_netstring_results", false, MAX_REQUEST_SIZE)));
+      netstring_server_t(context, "ipc:///tmp/test_netstring_server", "ipc:///tmp/test_netstring_proxy_upstream", "ipc:///tmp/test_netstring_results", "ipc:///tmp/test_netstring_interrupt", false, MAX_REQUEST_SIZE)));
     server.detach();
 
     //load balancer for parsing
@@ -159,7 +159,7 @@ namespace {
 
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
-      worker_t(context, "ipc:///tmp/test_netstring_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_netstring_results",
+      worker_t(context, "ipc:///tmp/test_netstring_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_netstring_results", "ipc:///tmp/test_netstring_interrupt",
       [] (const std::list<zmq::message_t>& job, void*) {
         worker_t::result_t result{false};
         auto request = netstring_entity_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -160,7 +160,7 @@ namespace {
     //echo worker
     std::thread worker(std::bind(&worker_t::work,
       worker_t(context, "ipc:///tmp/test_netstring_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_netstring_results", "ipc:///tmp/test_netstring_interrupt",
-      [] (const std::list<zmq::message_t>& job, void*) {
+      [] (const std::list<zmq::message_t>& job, void*, worker_t::interrupt_function_t&) {
         worker_t::result_t result{false};
         auto request = netstring_entity_t::from_string(static_cast<const char*>(job.front().data()), job.front().size());
         auto response = netstring_entity_t::to_string(request.body);

--- a/test/shaping.cpp
+++ b/test/shaping.cpp
@@ -54,7 +54,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_unshaped_server", "ipc:///tmp/test_unshaped_proxy_upstream", "ipc:///tmp/test_unshaped_results", false)));
+      netstring_server_t(context, "ipc:///tmp/test_unshaped_server", "ipc:///tmp/test_unshaped_proxy_upstream", "ipc:///tmp/test_unshaped_results", "ipc:///tmp/test_unshaped_interrupt", false)));
     server.detach();
 
     //load balancer for parsing
@@ -65,7 +65,7 @@ namespace {
     //a or b workers
     for(const auto& response : {std::string("A"), std::string("B")}) {
       std::thread worker(std::bind(&worker_t::work,
-        worker_t(context, "ipc:///tmp/test_unshaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_unshaped_results",
+        worker_t(context, "ipc:///tmp/test_unshaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_unshaped_results", "ipc:///tmp/test_unshaped_interrupt",
         [response] (const std::list<zmq::message_t>& job, void*) {
           worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
           return result;
@@ -93,7 +93,7 @@ namespace {
 
     //server
     std::thread server(std::bind(&netstring_server_t::serve,
-      netstring_server_t(context, "ipc:///tmp/test_shaped_server", "ipc:///tmp/test_shaped_proxy_upstream", "ipc:///tmp/test_shaped_results", false)));
+      netstring_server_t(context, "ipc:///tmp/test_shaped_server", "ipc:///tmp/test_shaped_proxy_upstream", "ipc:///tmp/test_shaped_results", "ipc:///tmp/test_shaped_interrupt", false)));
     server.detach();
 
     //load balancer for parsing that favors heartbeats (ie workers) based on whats in the job to be forwarded
@@ -120,7 +120,7 @@ namespace {
     //A or B workers
     for(const auto& response : {std::string("A"), std::string("B")}) {
       std::thread worker(std::bind(&worker_t::work,
-        worker_t(context, "ipc:///tmp/test_shaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_shaped_results",
+        worker_t(context, "ipc:///tmp/test_shaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_shaped_results", "ipc:///tmp/test_shaped_interrupt",
         [response] (const std::list<zmq::message_t>& job, void*) {
           worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
           return result;

--- a/test/shaping.cpp
+++ b/test/shaping.cpp
@@ -66,7 +66,7 @@ namespace {
     for(const auto& response : {std::string("A"), std::string("B")}) {
       std::thread worker(std::bind(&worker_t::work,
         worker_t(context, "ipc:///tmp/test_unshaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_unshaped_results", "ipc:///tmp/test_unshaped_interrupt",
-        [response] (const std::list<zmq::message_t>& job, void*) {
+        [response] (const std::list<zmq::message_t>& job, void*, worker_t::interrupt_function_t&) {
           worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
           return result;
         }, [](){}, response
@@ -121,7 +121,7 @@ namespace {
     for(const auto& response : {std::string("A"), std::string("B")}) {
       std::thread worker(std::bind(&worker_t::work,
         worker_t(context, "ipc:///tmp/test_shaped_proxy_downstream", "ipc:///dev/null", "ipc:///tmp/test_shaped_results", "ipc:///tmp/test_shaped_interrupt",
-        [response] (const std::list<zmq::message_t>& job, void*) {
+        [response] (const std::list<zmq::message_t>& job, void*, worker_t::interrupt_function_t&) {
           worker_t::result_t result{false, {netstring_entity_t::to_string(response)}, response};
           return result;
         }, [](){}, response

--- a/test/zmq.cpp
+++ b/test/zmq.cpp
@@ -5,11 +5,9 @@
 #include <string>
 #include <thread>
 
-#include <iostream>
-
 namespace {
 
-std::string readable_string(size_t size) {
+  std::string readable_string(size_t size) {
     std::string s(200, ' ');
     for(size_t i = 0; i < s.size(); ++i)
       s[i] = (i % 95) + 32;


### PR DESCRIPTION
This pr mainly fixes #45 

It adds two mechanisms by which a request and the work scheduled on it can be terminated. The two mechanisms are:

* the request takes longer than the specified timeout (default is no timeout)
* the client disconnects from the server

An interrupt socket using the pub/sub pattern is used to send this information to the workers. Each worker polls this socket to hear about jobs to terminate. When an interrupt is sent, it can be acted upon by the worker in two places. It can either reach the worker before the worker sees the job. Or it can reach the worker while the worker is working on the job. In the former case, the worker will abort the job without the application level logic knowing that the job ever existed. In the latter case the application level logic will need to allow for the cancellation to happen (the retrieving the of interrupt) via a periodic function call.

Both scenarios as well as the timeout scenario above are unit tested.

So far as I can tell the performance of the software is essentially completely unchanged. In fact recent changes to the number of messages being passed has made it so that in the limit (i test with `./prime_serverd 1000000 8`) the software is a little bit faster. Computing the primality of the first million positive integers (via http requests) in 16 seconds.

A bunch of other refactoring made it in here as I couldnt stand to look at it anymore. I hated having to derive a different type of server for a new protocol when you already had to pass (via template) a bunch of stuff that did protocol specific stuff. at this point it should me much easier to bring the templating down to a single protocol specific session_t object that does all of the protocol req/rep stuff.

@noblige @dnesbitt61 @patriciogonzalezvivo @zerebubuth note that this is a breaking set of API changes. quite on purpose!

with respect to making libvalhalla work with this there will need to be a bit of coordination:

- [x] release prime server 0.4.0
- [x] to lock current libvalhalla to 0.4.0
- [x] package and upload libvalhalla and references
- [ ] package and upload prime_server 0.6.0
- [ ] make libvalhalla compatibility changes 