### PR TITLE
wrong request id in log message, timeout didnt cancel work

### DIFF
--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -4,7 +4,7 @@
 //some version info
 #define PRIME_SERVER_VERSION_MAJOR 0
 #define PRIME_SERVER_VERSION_MINOR 6
-#define PRIME_SERVER_VERSION_PATCH 0
+#define PRIME_SERVER_VERSION_PATCH 1
 
 #include <functional>
 #include <string>

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -148,7 +148,7 @@ namespace prime_server {
 
   template <class request_container_t, class request_info_t>
   void server_t<request_container_t, request_info_t>::handle_timeouts() {
-    //kill timed out requests, NOTE: setting a huge request time out would be very stupid
+    //kill timed out requests
     auto drop_dead = static_cast<int64_t>(difftime(time(nullptr), 0) + .5) - request_timeout;
     while(drop_dead > 0 && request_history.size() && request_history.front().time_stamp < drop_dead) {
       interrupt.send(static_cast<void*>(&request_history.front()), sizeof(uint64_t), ZMQ_DONTWAIT);

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -472,7 +472,7 @@ namespace prime_server {
 
     //either we just got more or we need to check the backlog
     if((force_check || messages.size()) && interrupts.find(job) != interrupts.cend())
-      throw interrupt_t(job << 32);
+      throw interrupt_t(job & 0xFFFFFFFF);
   }
 
   //explicit instantiation for netstring and http

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -151,6 +151,7 @@ namespace prime_server {
     //kill timed out requests, NOTE: setting a huge request time out would be very stupid
     auto drop_dead = static_cast<int64_t>(difftime(time(nullptr), 0) + .5) - request_timeout;
     while(drop_dead > 0 && request_history.size() && request_history.front().time_stamp < drop_dead) {
+      interrupt.send(static_cast<void*>(&request_history.front()), sizeof(uint64_t), ZMQ_DONTWAIT);
       dequeue(request_history.front(), request_container_t::timeout(request_history.front()));
       request_history.pop_front();
     }


### PR DESCRIPTION
this fixes two problems.

first is that the log message when a request was interrupted at the worker level was always saying request id 0 was interrupted. this was because the bit arithmetic was wrong.

second is that when the clients request times out the worker was not notified of the timeout and told to abort the job if the client was using keepalive (which is all clients but http 1.0 clients)

wheres the emoji for faceplam?

@zerebubuth