### PR TITLE
more flexible header parsing

### DIFF
--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -4,7 +4,7 @@
 //some version info
 #define PRIME_SERVER_VERSION_MAJOR 0
 #define PRIME_SERVER_VERSION_MINOR 6
-#define PRIME_SERVER_VERSION_PATCH 1
+#define PRIME_SERVER_VERSION_PATCH 2
 
 #include <functional>
 #include <string>

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -431,10 +431,14 @@ namespace prime_server {
         case HEADERS: {
           //a header is here
           if(partial_buffer.size()) {
-            auto pos = partial_buffer.find(": ");
-            if(pos == std::string::npos)
+            //TODO: its really perverse but the rfc defines LWS (linear white space) to be not just space:
+            //LWS = [CRLF] 1*( SP | HT ), we could make a set above and move the value_begin while the char
+            //is in the set, basically implement TRIM.. lets instead hope to ditch our custom parser
+            size_t field_end, value_begin;
+            if((field_end = partial_buffer.find(':')) == std::string::npos ||
+               (value_begin = partial_buffer.find_first_not_of(' ', field_end + 1)) == std::string::npos)
               throw RESPONSE_400;
-            headers.insert({partial_buffer.substr(0, pos), partial_buffer.substr(pos + 2)});
+            headers.insert({partial_buffer.substr(0, field_end), partial_buffer.substr(value_begin)});
           }//the end or body
           else {
             //standard length specified

--- a/src/netstring_protocol.cpp
+++ b/src/netstring_protocol.cpp
@@ -10,7 +10,7 @@ using namespace prime_server;
 namespace {
 
 const netstring_entity_t::request_exception_t BAD_LENGTH("BAD_REQUEST: Non-numeric length");
-const netstring_entity_t::request_exception_t TOO_LONG("BAD_REQUEST: Request exceeded max");
+const netstring_entity_t::request_exception_t TOO_LONG("BAD_REQUEST: Request exceeded maximum length");
 const netstring_entity_t::request_exception_t BAD_BODY_SEPARATOR("BAD_REQUEST: Missing ':' between length and body");
 const netstring_entity_t::request_exception_t BAD_MESSAGE_SEPARATOR("BAD_REQUEST: Missing ',' after body");
 

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -153,6 +153,14 @@ namespace {
       throw std::runtime_error("Request parsing failed");
     if(request.to_info(0).connection_keep_alive != 1)
       throw std::runtime_error("Request parsing failed");
+
+    request_str = "GET /is_prime HTTP/1.1\r\ncOnTeNt-LeNgTh:         11\r\n\r\n32416190071";
+    request = http_request_t::from_string(request_str.c_str(), request_str.size());
+    if(request.body != "32416190071")
+      throw std::runtime_error("Request parsing failed");
+    auto content_length = request.headers.find("content-length");
+    if(content_length == request.headers.cend() || content_length->second != "11")
+      throw std::runtime_error("Request parsing failed");
   }
 
   void test_query_parsing() {

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -205,8 +205,8 @@ namespace {
       },
       [](const void* data, size_t size) {
         auto response = netstring_entity_t::from_string(static_cast<const char*>(data), size);
-        if(response.body.substr(0, 8) != "TOO_LONG")
-          throw std::runtime_error("Expected TOO_LONG response!");
+        if(response.body != "BAD_REQUEST: Request exceeded maximum length")
+          throw std::runtime_error("Expected exceeded max response!");
         return false;
       }, 1
     );


### PR DESCRIPTION
fixes #58 

apparently the spec for headers says you can basically put any kind of case in there and there can be any amount of whitespace between the field and the value of the header. so we've updated tests to make sure we allow that. previously tools like `ab` and `siege` didn't work because of this.

@dgearhart