### PR TITLE
Add a macOS build to the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,29 @@
 sudo: required
-dist: trusty
 language: cpp
-compiler:
-  - gcc
-env:
-before_install:
-  - export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g"`
-  - sudo add-apt-repository -y ppa:kevinkreiser/libsodium
-  - sudo add-apt-repository -y ppa:kevinkreiser/libpgm
-  - sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
-  - sudo add-apt-repository -y ppa:kevinkreiser/czmq
-  - sudo apt-get update
-install:
-  - sudo apt-get install -y -qq autoconf automake libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev libczmq-dev
-before_script:
-script:
-  ./autogen.sh && ./configure --enable-coverage && make test -j$(nproc)
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      before_install:
+        - export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -vF "#" | tr "\\n" ":" | sed -e "s/:$//g"`
+        - sudo add-apt-repository -y ppa:kevinkreiser/libsodium
+        - sudo add-apt-repository -y ppa:kevinkreiser/libpgm
+        - sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
+        - sudo add-apt-repository -y ppa:kevinkreiser/czmq
+        - sudo apt-get update
+      install:
+        - sudo apt-get install -y -qq autoconf automake libtool make gcc g++ lcov libcurl4-openssl-dev libzmq3-dev libczmq-dev
+      script:
+        - ./autogen.sh && ./configure --enable-coverage && make test -j$(nproc)
+    - os: osx
+      compiler: clang
+      before_install:
+        - brew update
+      install:
+        - brew install automake libtool zeromq czmq
+      script:
+        - ./autogen.sh && ./configure && make -j test
 after_failure:
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq
       script:
-        - ./autogen.sh && ./configure && make -j test
+        - ./autogen.sh && ./configure && make -j$(sysctl -n hw.ncpu) test
 after_failure:
   - cat config.log
   - cat test/*.log


### PR DESCRIPTION
Seems like we can build and pass tests on macOS! These builds will use Clang, so the GCC 'coverage' flags won't work. Clang has similar flags that can be used for this, I just ignored it for now.

Travis usually takes longer to start macOS builds than Ubuntu builds, unfortunately. CircleCI can start macOS builds much faster, if we find this to be an issue.