### PR TITLE
fix lots of warnings

### DIFF
--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -98,6 +98,7 @@ namespace prime_server {
 
     void log(size_t response_size) const;
     bool keep_alive() const { return (version == 0 && connection_keep_alive) || (version == 1 && !connection_close); }
+    explicit operator uint64_t() const { return static_cast<uint64_t>(id) | (static_cast<uint64_t>(time_stamp) << 32); }
   };
 
   class http_response_t;

--- a/prime_server/netstring_protocol.hpp
+++ b/prime_server/netstring_protocol.hpp
@@ -15,6 +15,7 @@ namespace prime_server {
 
     void log(size_t response_size) const;
     bool keep_alive() const { return true; }
+    explicit operator uint64_t() const { return static_cast<uint64_t>(id) | (static_cast<uint64_t>(time_stamp) << 32); }
   };
 
   struct netstring_entity_t {

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -407,6 +407,9 @@ namespace prime_server {
 
       //what are we looking to parse
       switch(state) {
+        case MESSAGE:
+        case CODE:
+          throw RESPONSE_500;
         case METHOD: {
           auto itr = STRING_TO_METHOD.find(partial_buffer);
           if(itr == STRING_TO_METHOD.end())
@@ -579,6 +582,9 @@ namespace prime_server {
 
       //what are we looking to parse
       switch(state) {
+        case METHOD:
+        case PATH:
+          throw std::runtime_error("invalid state");
         case MESSAGE: {
           //log_line = partial_buffer + delimiter;
           message.swap(partial_buffer);
@@ -630,7 +636,6 @@ namespace prime_server {
         }
         case CHUNKS: {
           //TODO: actually parse out the length and chunk by alternating
-          //TODO: return 501
           throw std::runtime_error("not implemented");
         }
       }

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -10,19 +10,6 @@ using namespace prime_server;
 
 namespace {
 
-  //check if base starts with pattern
-  bool startswith(const char* base, const char *pattern) {
-    if(base == nullptr || pattern == nullptr)
-      return false;
-    while(*base != '\0' && *pattern != '\0') {
-      if(*base != *pattern)
-        return false;
-      ++base;
-      ++pattern;
-    }
-    return true;
-  }
-
   const std::string CONTENT_LENGTH("\r\nContent-Length: ");
   const std::string DOUBLE_RETURN("\r\n\r\n");
 
@@ -192,7 +179,7 @@ namespace prime_server {
     if(body_length) {
       //while(current++ != end && --body_length);
       //we have enough
-      if(end - current > body_length) {
+      if(static_cast<size_t>(end - current) > body_length) {
         current += body_length;
         body_length = 0;
       }//we dont

--- a/src/http_util.cpp
+++ b/src/http_util.cpp
@@ -10,6 +10,7 @@
 
 using namespace prime_server::http;
 namespace {
+
   std::unordered_map<std::string, header_t> load_mimes() {
     //hardcode some just in case we cant get some automatically
     std::unordered_map<std::string, header_t> mimes{
@@ -24,18 +25,6 @@ namespace {
     //TODO: you can get some of these from /etc/mime.types
 
     return mimes;
-  }
-
-  struct stat canonical_path(const std::string& root, std::string& path) {
-    //yeah we only allow one dot at a time
-    for(size_t p = 0, i = path.find('.', 0); i != std::string::npos; p = i, i = path.find('.', i))
-      if(p + 1 == i)
-        path[p] = path[i] = '/';
-    //and this better be a regular file that exists
-    struct stat s;
-    if(stat((root + path).c_str(), &s))
-      s.st_mode = 0;
-    return s;
   }
 
 }
@@ -66,7 +55,7 @@ namespace prime_server {
       if(stat(canonical.c_str(), &s))
         s.st_mode = 0;
       //a regular file
-      if(s.st_size <= size_limit && (s.st_mode & S_IFREG)) {
+      if(static_cast<size_t>(s.st_size) <= size_limit && (s.st_mode & S_IFREG)) {
         //have to be able to open it
         std::fstream input(canonical, std::ios::in | std::ios::binary);
         if(input) {

--- a/src/http_util.cpp
+++ b/src/http_util.cpp
@@ -74,7 +74,6 @@ namespace prime_server {
           http_response_t response(200, "OK", buffer, headers_t{CORS, mime_header(path)});
           response.from_info(request_info);
           result.messages = {response.to_string()};
-          return result;
         }
       }//a directory
       else if(allow_listing && (s.st_mode & S_IFDIR)) {
@@ -96,12 +95,14 @@ namespace prime_server {
         http_response_t response(200, "OK", listing, headers_t{CORS, HTML_MIME});
         response.from_info(request_info);
         result.messages = {response.to_string()};
-        return result;
+      }//didn't make the cut
+      else {
+        http_response_t response(404, "Not Found", "Not Found");
+        response.from_info(request_info);
+        result.messages = {response.to_string()};
       }
-      //didn't make the cut
-      http_response_t response(404, "Not Found", "Not Found");
-      response.from_info(request_info);
-      result.messages = {response.to_string()};
+      //hand it back
+      return result;
     }
 
   }

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -242,7 +242,7 @@ namespace prime_server {
       if(log)
         parsed_request.log(info.id);
       //remember we are working on it
-      request.enqueued.emplace_back(*static_cast<typename decltype(requests)::key_type*>(static_cast<void*>(&info)));
+      request.enqueued.emplace_back(static_cast<typename decltype(requests)::key_type>(info));
       this->requests.emplace(request.enqueued.back(), requester);
       this->request_history.emplace_back(std::move(info));
     }
@@ -252,7 +252,7 @@ namespace prime_server {
   template <class request_container_t, class request_info_t>
   bool server_t<request_container_t, request_info_t>::dequeue(const request_info_t& info, const zmq::message_t& response) {
     //find the request
-    auto request = requests.find(*static_cast<const typename decltype(requests)::key_type*>(static_cast<const void*>(&info)));
+    auto request = requests.find(static_cast<typename decltype(requests)::key_type>(info));
     if(request == requests.cend())
       return false;
     //reply to the client with the response or an error

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -407,6 +407,8 @@ int main() {
 
   suite.test(TEST_CASE(test_response));
 
+  suite.test(TEST_CASE(test_response_parsing));
+
   suite.test(TEST_CASE(test_parallel_clients));
 
   suite.test(TEST_CASE(test_malformed));

--- a/test/zmq.cpp
+++ b/test/zmq.cpp
@@ -306,7 +306,7 @@ namespace {
       zmq::pollitem_t item{ sub, 0, ZMQ_POLLIN, 0 };
       zmq::poll(&item, 1, -1);
 
-      if(item.revents & ZMQ_POLLIN == false)
+      if(!(item.revents & ZMQ_POLLIN))
         throw std::logic_error("Poller triggered but not for the right socket");
       auto messages = sub.recv_all(0);
       if(messages.size() != 1)


### PR DESCRIPTION
this fixes a bunch of things that clang warns about but gcc doesnt. the most egregious was the infamous missing return, where gcc happily returns the right thing even if you dont. thankfully clang caught it. also it was just more beta functionality for file hosting, nothing critical at this point for systems using prime_server.

then i turned on `-Wall` and found a bunch of other stuff that i fixed, the most dangerous sounding was the dreaded punned pointer aliasing.

anyway all should now be well. i'll take a look at the random test failure issues in a separate pr.

thanks again @matteblair!