### PR TITLE
add support for chunked requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-        - ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test -j$(sysctl -n hw.ncpu)
+        - ./autogen.sh && ./configure CFLAGS="-g3 -O2" CXXFLAGS="-g3 -O2" && make test -j$(sysctl -n hw.ncpu)
 after_failure:
   - ulimit -c unlimited
   - test/interrupt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-		- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
+	- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
 after_failure:
   - ls -al
   - libtool --mode=execute gdb test/interrupt core -ex where

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq
       script:
-        - ./autogen.sh && ./configure CFLAGS='-fsanitize=address' && make -j$(sysctl -n hw.ncpu) && test/interrupt
+        - ./autogen.sh && ./configure CFLAGS='-fsanitize=address' && make -j$(sysctl -n hw.ncpu) test/interrupt && test/interrupt
 after_failure:
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-	- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
+        - ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
 after_failure:
   - ls -al
   - libtool --mode=execute gdb test/interrupt core -ex where

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq
       script:
-        - ./autogen.sh && ./configure && make -j$(sysctl -n hw.ncpu) test
+        - ./autogen.sh && ./configure CFLAGS='-fsanitize=address' && make -j$(sysctl -n hw.ncpu) && test/interrupt
 after_failure:
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-        - ./autogen.sh && ./configure CFLAGS="-O2" CXXFLAGS="-O2" && make test -j$(sysctl -n hw.ncpu)
+        - ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test -j$(sysctl -n hw.ncpu)
 after_failure:
   - ulimit -c unlimited
   - test/interrupt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-		- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0"
-		- make test/interrupt -j$(sysctl -n hw.ncpu)
-		- ulimit -c unlimited
-		- test/interrupt
+		- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
 after_failure:
   - ls -al
   - libtool --mode=execute gdb test/interrupt core -ex where

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,14 @@ matrix:
       before_install:
         - brew update
       install:
-        - brew install automake libtool zeromq czmq
+        - brew install automake libtool zeromq czmq gdb
       script:
-        - ./autogen.sh && ./configure CFLAGS='-fsanitize=address' && make -j$(sysctl -n hw.ncpu) test/interrupt && test/interrupt
+		- ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0"
+		- make test/interrupt -j$(sysctl -n hw.ncpu)
+		- ulimit -c unlimited
+		- test/interrupt
 after_failure:
+  - ls -al
+  - libtool --mode=execute gdb test/interrupt core -ex where
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ matrix:
       before_install:
         - brew update
       install:
-        - brew install automake libtool zeromq czmq gdb
+        - brew install automake libtool zeromq czmq
       script:
-        - ./autogen.sh && ./configure CFLAGS="-g3 -O2" CXXFLAGS="-g3 -O2" && make test -j$(sysctl -n hw.ncpu)
+        - ./autogen.sh && ./configure CFLAGS="-O0" CXXFLAGS="-O0" && make test -j$(sysctl -n hw.ncpu)
 after_failure:
   - ulimit -c unlimited
   - test/interrupt

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
 after_failure:
   - ulimit -c unlimited
   - test/interrupt
+  - ls -al
+  - libtool --help
   - libtool --mode=execute gdb test/interrupt core -ex where
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,5 @@ matrix:
       script:
         - ./autogen.sh && ./configure CFLAGS="-O0" CXXFLAGS="-O0" && make test -j$(sysctl -n hw.ncpu)
 after_failure:
-  - ulimit -c unlimited
-  - test/interrupt
-  - ls -al
-  - libtool --help
-  - libtool --mode=execute gdb test/interrupt core -ex where
   - cat config.log
   - cat test/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,10 @@ matrix:
       install:
         - brew install automake libtool zeromq czmq gdb
       script:
-        - ./autogen.sh && ./configure CFLAGS="-g3 -O0" CXXFLAGS="-g3 -O0" && make test/interrupt -j$(sysctl -n hw.ncpu) && ulimit -c unlimited && test/interrupt
+        - ./autogen.sh && ./configure CFLAGS="-O2" CXXFLAGS="-O2" && make test -j$(sysctl -n hw.ncpu)
 after_failure:
-  - ls -al
+  - ulimit -c unlimited
+  - test/interrupt
   - libtool --mode=execute gdb test/interrupt core -ex where
   - cat config.log
   - cat test/*.log

--- a/prime_server/http_protocol.hpp
+++ b/prime_server/http_protocol.hpp
@@ -72,7 +72,7 @@ namespace prime_server {
     virtual ~http_entity_t();
     virtual std::string to_string() const = 0;
    protected:
-    enum state_t { METHOD, MESSAGE, CODE, PATH, VERSION, HEADERS, BODY, CHUNKS };
+    enum state_t { METHOD, MESSAGE, CODE, PATH, VERSION, HEADERS, BODY, CHUNK_LENGTH, CHUNK, TRAILER };
     virtual void flush_stream(const state_t state);
 
     //state for streaming parsing

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -474,8 +474,7 @@ namespace prime_server {
         }
         case CHUNK: {
           //drop the CRLF part of the chunk
-          body.append(partial_buffer, 0, body_length);
-          body_length = 0;
+          body.append(partial_buffer);
           state = CHUNK_LENGTH;
           break;
         }

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -187,20 +187,20 @@ namespace prime_server {
         body_length -= end - current;
         current = end;
       }
-      c = body_length != 0;
-    }//go until delimiter
-    else {
-      while((c = *(delimiter + partial_length)) != '\0' && current != end) {
-        if(c != *current)
-          partial_length = 0;
-        else
-          ++partial_length;
-        ++current;
-      }
     }
+
+    //go until delimiter
+    while((c = *(delimiter + partial_length)) != '\0' && current != end) {
+      if(c != *current)
+        partial_length = 0;
+      else
+        ++partial_length;
+      ++current;
+    }
+
     //we found the delimiter
     size_t length = current - cursor;
-    if(c == '\0') {
+    if(c == '\0' && !body_length) {
       if(length < partial_length)
         partial_buffer.resize(partial_buffer.size() - (partial_length - length));
       else
@@ -210,6 +210,7 @@ namespace prime_server {
       consumed += length;
       return true;
     }
+
     //we ran out
     partial_buffer.append(cursor, length);
     return false;
@@ -423,6 +424,7 @@ namespace prime_server {
           state = HEADERS;
           break;
         }
+        case TRAILER:
         case HEADERS: {
           //a header is here
           if(partial_buffer.size()) {
@@ -438,14 +440,16 @@ namespace prime_server {
           else {
             //standard length specified
             headers_t::const_iterator value;
-            if((value = headers.find("Content-Length")) != headers.end()) {
+            if(state != TRAILER && (value = headers.find("Content-Length")) != headers.end()) {
               try{ body_length = std::stoul(value->second); }
               catch(...) { throw RESPONSE_400; }
+              delimiter = "";
               state = BODY;
             }//streaming chunks
-            else if((value = headers.find("Transfer-Encoding")) != headers.end() && value->second == "chunked") {
-              state = CHUNKS;
-            }//simple GET
+            else if(state != TRAILER && (value = headers.find("Transfer-Encoding")) != headers.end()
+                && value->second == "chunked") {
+              state = CHUNK_LENGTH;
+            }//simple GET or end of TRAILER
             else {
               requests.emplace_back(method, path, body, query, headers, version);
               requests.back().log_line.swap(log_line);
@@ -461,9 +465,19 @@ namespace prime_server {
           flush_stream();
           break;
         }
-        case CHUNKS: {
-          //TODO: actually parse out the length and chunk by alternating
-          throw RESPONSE_501;
+        case CHUNK_LENGTH: {
+          //TODO: dont ignore extensions
+          try { body_length = std::stoul(partial_buffer, nullptr, 16); }
+          catch(...) { throw RESPONSE_400; }
+          state = body_length ? CHUNK : TRAILER;
+          break;
+        }
+        case CHUNK: {
+          //drop the CRLF part of the chunk
+          body.append(partial_buffer, 0, body_length);
+          body_length = 0;
+          state = CHUNK_LENGTH;
+          break;
         }
       }
 
@@ -602,13 +616,16 @@ namespace prime_server {
             headers.insert({partial_buffer.substr(0, pos), partial_buffer.substr(pos + 2)});
           }//the end or body
           else {
-            auto length_str = headers.find("Content-Length");
-            if(length_str != headers.end()) {
-              body_length = std::stoul(length_str->second);
+            auto value = headers.find("Content-Length");
+            if(value != headers.end()) {
+              body_length = std::stoul(value->second);
+              delimiter = "";
               state = BODY;
+            }//streaming chunks
+            else if((value = headers.find("Transfer-Encoding")) != headers.end() && value->second == "chunked") {
+              state = CHUNK_LENGTH;
             }
             else {
-              //TODO: check for chunked
               responses.emplace_back(code, message, body, headers, version);
               flush_stream();
             }
@@ -621,8 +638,12 @@ namespace prime_server {
           flush_stream();
           break;
         }
-        case CHUNKS: {
-          //TODO: actually parse out the length and chunk by alternating
+        case CHUNK_LENGTH: {
+          //TODO: actually parse out the length
+          throw std::runtime_error("not implemented");
+        }
+        case CHUNK: {
+          //TODO: add the chunk to the body
           throw std::runtime_error("not implemented");
         }
       }

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -410,6 +410,9 @@ namespace {
         reqs.front().headers.begin()->second != "chunked")
       throw std::logic_error("Should have a single transfer encoding header set to chunked");
 
+    if(reqs.front().body != "a chunk with \r\n in itachunkwithanexstensiondone")
+      throw std::logic_error("The chunked body was wrong");
+
     //reset for another with trailer
     req.flush_stream();
     piece = "POST /is_prime HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n15\r\na chunk with \r\n in it";
@@ -422,7 +425,12 @@ namespace {
     if(reqs.size() != 0)
       throw std::logic_error("There should be no full requests yet");
 
-    piece = "4\r\ndone\r\n0\r\ntrailerA: A\r\ntrailerB: B\r\n\r\n";
+    piece = "5\r\nsp";
+    reqs = req.from_stream(piece.c_str(), piece.size());
+    if(reqs.size() != 0)
+      throw std::logic_error("There should be no full requests yet");
+
+    piece = "lit\r\n0\r\ntrailerA: A\r\ntrailerB: B\r\n\r\n";
     reqs = req.from_stream(piece.c_str(), piece.size());
     if(reqs.size() != 1)
       throw std::logic_error("There should be 1 full reply now");
@@ -433,6 +441,9 @@ namespace {
         b == reqs.front().headers.cend() || a->first != "trailerA" || b->first != "trailerB" ||
         a->second != "A" || b->second != "B")
       throw std::logic_error("Should have 3 headers, 1 for chunked and 2 in the trailer");
+
+    if(reqs.front().body != "a chunk with \r\n in itachunkwithanexstensionsplit")
+      throw std::logic_error("The chunked body was wrong");
   }
 
 }

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -449,8 +449,6 @@ namespace {
 }
 
 int main() {
-  //make this whole thing bail if it doesnt finish fast
-  alarm(240);
 
   testing::suite suite("http");
 
@@ -468,6 +466,11 @@ int main() {
 
   suite.test(TEST_CASE(test_response_parsing));
 
+  suite.test(TEST_CASE(test_chunked_encoding));
+
+  //fail if it hangs
+  alarm(300);
+
   suite.test(TEST_CASE(test_parallel_clients));
 
   suite.test(TEST_CASE(test_malformed));
@@ -476,7 +479,7 @@ int main() {
 
   suite.test(TEST_CASE(test_large_request));
 
-  suite.test(TEST_CASE(test_chunked_encoding));
+
 
   return suite.tear_down();
 }

--- a/test/interrupt.cpp
+++ b/test/interrupt.cpp
@@ -92,7 +92,7 @@ namespace {
       netstring_server_t(context, "ipc:///tmp/test_loop_server", "ipc:///tmp/test_loop_proxy_upstream", "ipc:///tmp/test_loop_results", "ipc:///tmp/test_loop_interrupt", false)));
     server.detach();
 
-    //we want a client that is very fickle, we need the client to send a request and then bail right away before
+    //we want a client that is very fickle, we need the client to send a request and then bail right away
     //clients always work in batch mode which is to say they send n requests and then wait for n responses. to trick
     //the client into hanging up without a response we've made it so that the act of making a request sets the expected
     //number of responses to 0. this will skip the loop that tries to collect n responses because it thinks it needs 0

--- a/test/netstring.cpp
+++ b/test/netstring.cpp
@@ -246,8 +246,6 @@ namespace {
 }
 
 int main() {
-  //make this whole thing bail if it doesnt finish fast
-  alarm(240);
 
   testing::suite suite("netstring");
 
@@ -256,6 +254,9 @@ int main() {
   suite.test(TEST_CASE(test_streaming_server));
 
   suite.test(TEST_CASE(test_entity));
+
+  //fail if it hangs
+  alarm(300);
 
   suite.test(TEST_CASE(test_parallel_clients));
 


### PR DESCRIPTION
this adds support for chunked requests. since the implementation of the request and response are shared, adding it to the response was very easy however the server side of the api doesnt have a clean model for allowing workers to stream chunked responses. once we work that out this library would be much more useful for file serving scenarios.

one interesting thing to note is that a lot of client side libraries (libcurl) will do an `expect: 100-continue` before issuing the `transfer-encoding: chunked` request to see if the server supports it. apparently nodejs isnt one of those libraries... at any rate we have another branch with a start on `expect: 100-continue` going but thats not going to make it in very soon most likely.