### PR TITLE
fixes #73 fixes #65

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       before_install:
         - brew update
       install:
-        - brew install automake libtool zeromq czmq #cmake
+        - brew install libtool zeromq czmq #automake cmake
       script:
         - ./autogen.sh && ./configure && make all test -j$(sysctl -n hw.ncpu)
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ matrix:
         - sudo add-apt-repository -y ppa:kevinkreiser/czmq
         - sudo apt-get update
       install:
-        - sudo apt-get install -y -qq make cmake gcc g++ libcurl4-openssl-dev libzmq3-dev libczmq-dev
+        - sudo apt-get install -y -qq autoconf automake libtool make cmake gcc g++ lcov libcurl4-openssl-dev libzmq3-dev libczmq-dev
       script:
-        - cmake . && make all test -j$(nproc)
+        - ./autogen.sh && ./configure && make all test -j$(nproc)
     - os: osx
       compiler: clang
       before_install:
         - brew update
       install:
-        - brew install zeromq czmq #cmake
+        - brew install automake libtool zeromq czmq cmake
       script:
-        - cmake . && make all test -j$(sysctl -n hw.ncpu)
+        - ./autogen.sh && ./configure && make all test -j$(sysctl -n hw.ncpu)
 after_failure:
   - cat build/CMakeCache.txt
   - cat build/Testing/Temporary/LastTest.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       before_install:
         - brew update
       install:
-        - brew install automake libtool zeromq czmq cmake
+        - brew install automake libtool zeromq czmq #cmake
       script:
         - ./autogen.sh && ./configure && make all test -j$(sysctl -n hw.ncpu)
 after_failure:

--- a/prime_server/prime_server.hpp
+++ b/prime_server/prime_server.hpp
@@ -106,11 +106,12 @@ namespace prime_server {
     //allows you to favor a certain heartbeat/worker for a given job
     using choose_function_t = std::function<const zmq::message_t* (const std::list<zmq::message_t>&, const std::list<zmq::message_t>&)>;
     proxy_t(zmq::context_t& context, const std::string& upstream_endpoint, const std::string& downstream_endpoint,
-      const choose_function_t& choose_function = [](const std::list<zmq::message_t>&, const std::list<zmq::message_t>&){return nullptr;});
+      const choose_function_t& choose_function = no_selection);
     virtual ~proxy_t();
     void forward();
    protected:
     virtual int expire();
+    static const zmq::message_t* no_selection(const std::list<zmq::message_t>&, const std::list<zmq::message_t>&);
 
     zmq::socket_t upstream;
     zmq::socket_t downstream;
@@ -142,12 +143,13 @@ namespace prime_server {
 
     worker_t(zmq::context_t& context, const std::string& upstream_proxy_endpoint, const std::string& downstream_proxy_endpoint,
       const std::string& result_endpoint, const std::string& interrupt_endpoint, const work_function_t& work_function,
-      const cleanup_function_t& cleanup_function = [](){}, const std::string& heart_beat = "");
+      const cleanup_function_t& cleanup_function = no_cleanup, const std::string& heart_beat = "");
     virtual ~worker_t();
     void work();
    protected:
     void advertise();
     virtual void handle_interrupt(bool force_check);
+    static void no_cleanup();
 
     zmq::socket_t upstream_proxy;
     zmq::socket_t downstream_proxy;

--- a/src/prime_server.cpp
+++ b/src/prime_server.cpp
@@ -366,6 +366,9 @@ namespace prime_server {
       }
     }
   }
+  const zmq::message_t* proxy_t::no_selection(const std::list<zmq::message_t>&, const std::list<zmq::message_t>&) {
+    return nullptr;
+  }
 
   worker_t::worker_t(zmq::context_t& context, const std::string& upstream_proxy_endpoint, const std::string& downstream_proxy_endpoint,
                      const std::string& result_endpoint, const std::string& interrupt_endpoint, const work_function_t& work_function,
@@ -489,6 +492,7 @@ namespace prime_server {
     if((force_check || messages.size()) && interrupts.find(job) != interrupts.cend())
       throw interrupt_t(job & 0xFFFFFFFF);
   }
+  void worker_t::no_cleanup(){}
 
   //explicit instantiation for netstring and http
   template class server_t<netstring_entity_t, netstring_request_info_t>;


### PR DESCRIPTION
in the constructor for worker and proxy we take a copy of an std function. in the case of not providing those we take a copy of a temporary lambda. this should be fine since they are copies but in practice on osx we seem to have an issue with this when building with gnu tools. this is an attempt to get to the bottom of this..