### PR TITLE
Update macos cmake instructions with -DCMAKE_OSX_SYSROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ In case autotools is failing for some reason, you can try CMake:
 cd prime_server
 cmake -B build .
 cmake --build build
-# on Big Sur it may be necessary to specify SYSROOT
-cmake --build build -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk"
+# if this failed it may be necessary to specify SYSROOT (on Big Sur for example)
+if [ $? -ne 0 ]; then
+  cmake --build build -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk"
+fi
 # if you want build the test:
 make -C build test
 sudo make -C build install

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ In case autotools is failing for some reason, you can try CMake:
 cd prime_server
 cmake -B build .
 cmake --build build
+# on Big Sur it may be necessary to specify SYSROOT
+cmake --build build -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk"
 # if you want build the test:
 make -C build test
 sudo make -C build install


### PR DESCRIPTION
I found this change to the cmake command was necessary to successfully build on MacOS Big Sur 11.2.3.