### PR TITLE
define VERSION for pc.in file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ set(bindir "${CMAKE_INSTALL_PREFIX}/bin")
 set(libdir "${CMAKE_INSTALL_PREFIX}/lib")
 set(includedir "${CMAKE_INSTALL_PREFIX}/include/prime_server")
 set(pkgconfigdir "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
+set(VERSION ${PROJECT_VERSION})
 
 install(TARGETS prime_server
 	LIBRARY DESTINATION ${libdir}


### PR DESCRIPTION
fixes #106 

Tried a local installation, which now produces a valid `Version` in `libprime_server.pc.in`.