### PR TITLE
patch autotools for newer toolchains

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -19,6 +19,7 @@ jobs:
         run: |
           xcrun --show-sdk-path
           SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk | head -n1)
+          echo ${SDK_PATH}
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=${SDK_PATH} && make all -j$(sysctl -n hw.ncpu)
       - name: test
         shell: bash

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,8 +18,7 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
-          find /Library/Developer/CommandLineTools
-          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path) && make all -j$(sysctl -n hw.ncpu)
+          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk" && make all -j$(sysctl -n hw.ncpu)
       - name: test
         shell: bash
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,7 +18,8 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
-          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk" && make all -j$(sysctl -n hw.ncpu)
+          SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk | head -n1)
+          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=${SDK_PATH} && make all -j$(sysctl -n hw.ncpu)
       - name: test
         shell: bash
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,7 +18,7 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
-          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk" && make all -j$(sysctl -n hw.ncpu)
+          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path) && make all -j$(sysctl -n hw.ncpu)
       - name: test
         shell: bash
         run: |

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,6 +18,7 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
+          find /Library/Developer/CommandLineTools
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path) && make all -j$(sysctl -n hw.ncpu)
       - name: test
         shell: bash

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,8 +18,7 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
-          find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk -type d -maxdepth 1
-          SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.*.sdk -type d | head -n1)
+          SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk -type d -maxdepth 0)
           echo ${SDK_PATH}
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=${SDK_PATH} && make all -j$(sysctl -n hw.ncpu)
       - name: test

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -18,7 +18,8 @@ jobs:
         shell: bash
         run: |
           xcrun --show-sdk-path
-          SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk | head -n1)
+          find /Library/Developer/CommandLineTools/SDKs/MacOSX*.sdk -type d -maxdepth 1
+          SDK_PATH=$(find /Library/Developer/CommandLineTools/SDKs/MacOSX*.*.sdk -type d | head -n1)
           echo ${SDK_PATH}
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_SANITIZERS=On -DCMAKE_OSX_SYSROOT=${SDK_PATH} && make all -j$(sysctl -n hw.ncpu)
       - name: test

--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@
 On Linux:
 
 ```bash
-# trusty didn't have czmq or newer zmq in the repositories so its repackaged here
-if [[ $(grep -cF trusty /etc/lsb-release) > 0 ]]; then
-  sudo add-apt-repository -y ppa:kevinkreiser/libsodium
-  sudo add-apt-repository -y ppa:kevinkreiser/libpgm
-  sudo add-apt-repository -y ppa:kevinkreiser/zeromq3
-  sudo add-apt-repository -y ppa:kevinkreiser/czmq
-  sudo apt-get update
-fi
 # grab some standard autotools stuff
 sudo apt-get install autoconf automake libtool make gcc g++ lcov
 # grab curl (for url de/encode) and zmq for the awesomeness

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On Linux:
 
 ```bash
 # grab some standard autotools stuff
-sudo apt-get install autoconf automake libtool make gcc g++ lcov
+sudo apt-get install autoconf automake pkg-config libtool make gcc g++ lcov
 # grab curl (for url de/encode) and zmq for the awesomeness
 sudo apt-get install libcurl4-openssl-dev libzmq3-dev libczmq-dev
 ```

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 aclocal -I m4
 autoreconf -fi --warning=no-portability
+automake --add-missing

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 aclocal -I m4
 autoreconf -fi --warning=no-portability
 automake --add-missing

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,10 @@
-AC_INIT([prime_server],
-	[m4_esyscmd([./version.sh])],
-	[https://github.com/kevinkreiser/prime_server/issues],
-	[prime_server-[m4_esyscmd([./version.sh])]],
-	[https://github.com/kevinkreiser/prime_server])
+CODE_VERSION=`./version.sh`
+AC_INIT(
+    [prime_server],
+    [$(CODE_VERSION)],
+    [https://github.com/kevinkreiser/prime_server/issues],
+    [prime_server-$(CODE_VERSION)],
+    [https://github.com/kevinkreiser/prime_server])
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects parallel-tests])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
@@ -24,8 +26,10 @@ AC_PROG_CXX
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
-AC_HEADER_STDC
-AC_LANG_CPLUSPLUS
+AC_CHECK_INCLUDES_DEFAULT
+AC_PROG_EGREP
+
+AC_LANG([C++])
 
 # require c++11
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,7 @@ AC_LANG([C++])
 AX_CXX_COMPILE_STDCXX_11([noext],[mandatory])
 
 # check zmq version
-PKG_CHECK_MODULES([DEPS], [libzmq >= 4.1.4 libczmq >= 3.0 libcurl >= 7.22.0])
+PKG_CHECK_MODULES(DEPS, [libzmq >= 4.1.4 libczmq >= 3.0 libcurl >= 7.22.0])
 
 # require pthread as a regular dep because we need it everywhere
 AX_PTHREAD(, [AC_MSG_ERROR([cannot find libpthread])])

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,8 @@
-AC_INIT(
-    [prime_server],
-    [m4_esyscmd([./version.sh])],
-    [https://github.com/kevinkreiser/prime_server/issues],
-    [prime_server-m4_esyscmd([./version.sh])],
-    [https://github.com/kevinkreiser/prime_server])
+AC_INIT([prime_server],
+        [m4_esyscmd([./version.sh])],
+        [https://github.com/kevinkreiser/prime_server/issues],
+        [prime_server-m4_esyscmd([./version.sh])],
+        [https://github.com/kevinkreiser/prime_server])
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects parallel-tests])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,8 @@
-CODE_VERSION=`./version.sh`
 AC_INIT(
     [prime_server],
-    [$(CODE_VERSION)],
+    [m4_esyscmd([./version.sh])],
     [https://github.com/kevinkreiser/prime_server/issues],
-    [prime_server-$(CODE_VERSION)],
+    [prime_server-m4_esyscmd([./version.sh])],
     [https://github.com/kevinkreiser/prime_server])
 AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall -Werror subdir-objects parallel-tests])

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -294,7 +294,7 @@ if test "x$ax_pthread_clang" = "xyes"; then
              # step
              ax_pthread_save_ac_link="$ac_link"
              ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
              ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
              ax_pthread_save_CFLAGS="$CFLAGS"
              for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do


### PR DESCRIPTION
i believe this fixes #100 

i recently updated to ubuntu 22.04 and was hitting the issue referenced above. i made some tweaks to properly use the buildin macros.

@nilsnolde you were hitting this one too at one point but moved on to cmake. this might work again for you now but i didnt try in arch tbh.

anyway, starting up a fresh docker container of 22.04 exposes the issue and when i checkout this branch it goes away and builds like a charm

this also updates the mac build to the latest build chain in CI