### PR TITLE
allow empty header values

### DIFF
--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -460,10 +460,10 @@ http_request_t::from_stream(const char* start, size_t length, size_t max_size) {
           // while the char is in the set, basically implement TRIM.. lets instead hope to ditch our
           // custom parser
           size_t field_end, value_begin;
-          if ((field_end = partial_buffer.find(':')) == std::string::npos ||
-              (value_begin = partial_buffer.find_first_not_of(' ', field_end + 1)) ==
-                  std::string::npos)
+          if ((field_end = partial_buffer.find(':')) == std::string::npos)
             throw RESPONSE_400;
+          if ((value_begin = partial_buffer.find_first_not_of(' ', field_end + 1)) == std::string::npos)
+            value_begin = partial_buffer.size();
           headers.insert({partial_buffer.substr(0, field_end), partial_buffer.substr(value_begin)});
         } // the end or body
         else {

--- a/src/http_protocol.cpp
+++ b/src/http_protocol.cpp
@@ -51,7 +51,8 @@ const http_request_t::request_exception_t
                                  "The HTTP request version is not supported",
                                  {CORS}));
 
-template <class T> size_t name_max(const std::unordered_map<std::string, T>& methods) {
+template <class T>
+size_t name_max(const std::unordered_map<std::string, T>& methods) {
   size_t i = 0;
   for (const auto& kv : methods)
     i = std::max(i, kv.first.size());
@@ -462,7 +463,8 @@ http_request_t::from_stream(const char* start, size_t length, size_t max_size) {
           size_t field_end, value_begin;
           if ((field_end = partial_buffer.find(':')) == std::string::npos)
             throw RESPONSE_400;
-          if ((value_begin = partial_buffer.find_first_not_of(' ', field_end + 1)) == std::string::npos)
+          if ((value_begin = partial_buffer.find_first_not_of(' ', field_end + 1)) ==
+              std::string::npos)
             value_begin = partial_buffer.size();
           headers.insert({partial_buffer.substr(0, field_end), partial_buffer.substr(value_begin)});
         } // the end or body

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -190,15 +190,19 @@ void test_request_parsing() {
   if (content_length == request.headers.cend() || content_length->second != "11")
     throw std::runtime_error("Request parsing failed");
 
-  request_str = "GET /empty HTTP/1.1\r\nx-often-empty-header:         \r\n\r\nfoo";
+  request_str = "GET /empty HTTP/1.1\r\nx-often-empty-header:         \r\n\r\n";
   request = http_request_t::from_string(request_str.c_str(), request_str.size());
-  if (request.body != "foo")
-    throw std::runtime_error("Request parsing failed");
   auto empty = request.headers.find("x-often-empty-header");
   if (empty == request.headers.cend() || !empty->second.empty())
     throw std::runtime_error("Request parsing failed");
 
-  request_str = "GET /bad_header HTTP/1.1\r\nx-bad-header-no-colon         \r\n\r\nbar";
+  request_str = "GET /empty HTTP/1.1\r\nx-often-empty-header:\r\n\r\n";
+  request = http_request_t::from_string(request_str.c_str(), request_str.size());
+  auto still_empty = request.headers.find("x-often-empty-header");
+  if (still_empty == request.headers.cend() || !still_empty->second.empty())
+    throw std::runtime_error("Request parsing failed");
+
+  request_str = "GET /bad_header HTTP/1.1\r\nx-bad-header-no-colon         \r\n\r\n";
   try {
     request = http_request_t::from_string(request_str.c_str(), request_str.size());
     throw std::runtime_error("Request parsing should have failed");

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -39,12 +39,12 @@ public:
   // remember the last response that was sent
   std::vector<http_response_t> last_responses;
   virtual bool dequeue(const http_request_info_t& info, const zmq::message_t& response) {
-    last_responses.emplace_back(http_response_t::from_string(static_cast<const char*>(response.data()), response.size()));
+    last_responses.emplace_back(
+        http_response_t::from_string(static_cast<const char*>(response.data()), response.size()));
     try {
       return http_server_t::dequeue(info, response);
-    }
-    catch(const std::runtime_error& e){
-      if(std::string(e.what()).find("unreachable") == std::string::npos) {
+    } catch (const std::runtime_error& e) {
+      if (std::string(e.what()).find("unreachable") == std::string::npos) {
         throw e;
       }
     }
@@ -286,10 +286,9 @@ void test_response_parsing() {
 void test_shortcircuit() {
   // a server who lets us snoop on what its doing
   zmq::context_t context;
-  testable_http_server_t server(context, "ipc:///tmp/test_http_server",
-                                "ipc:///tmp/test_http_proxy_upstream", "ipc:///tmp/test_http_results",
-                                "ipc:///tmp/test_http_interrupt", false,
-      MAX_REQUEST_SIZE, -1,
+  testable_http_server_t server(
+      context, "ipc:///tmp/test_http_server", "ipc:///tmp/test_http_proxy_upstream",
+      "ipc:///tmp/test_http_results", "ipc:///tmp/test_http_interrupt", false, MAX_REQUEST_SIZE, -1,
       [](const http_request_t& r) -> bool { return r.path == "/health_check"; },
       http_response_t{200, "OK", "foo_bar_baz"}.to_string());
   server.passify();

--- a/test/http.cpp
+++ b/test/http.cpp
@@ -189,6 +189,23 @@ void test_request_parsing() {
   auto content_length = request.headers.find("content-length");
   if (content_length == request.headers.cend() || content_length->second != "11")
     throw std::runtime_error("Request parsing failed");
+
+  request_str = "GET /empty HTTP/1.1\r\nx-often-empty-header:         \r\n\r\nfoo";
+  request = http_request_t::from_string(request_str.c_str(), request_str.size());
+  if (request.body != "foo")
+    throw std::runtime_error("Request parsing failed");
+  auto empty = request.headers.find("x-often-empty-header");
+  if (empty == request.headers.cend() || !empty->second.empty())
+    throw std::runtime_error("Request parsing failed");
+
+  request_str = "GET /bad_header HTTP/1.1\r\nx-bad-header-no-colon         \r\n\r\nbar";
+  try {
+    request = http_request_t::from_string(request_str.c_str(), request_str.size());
+    throw std::runtime_error("Request parsing should have failed");
+  } catch (const http_request_t::request_exception_t& e) {
+    if (e.code != 400)
+      throw std::runtime_error("Request parsing failed");
+  }
 }
 
 void test_query_parsing() {


### PR DESCRIPTION
@nilsnolde is making good progress on vector tile serving and noticed an issue when hooking it up to qgis. prime_server chokes on the requests. he did all the hard work of debugging it to the section of code that parses header names and values. basic gist is, prime_server wasnt allowing empty values. i guess i didnt read the rfc all that carefully.. anyway this pr adds tests for and fixes that.